### PR TITLE
Adding parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+.vscode
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
@@ -21,9 +21,22 @@ namespace AutoMapper.AspNet.OData
         /// <param name="mapper"></param>
         /// <param name="options"></param>
         /// <returns></returns>
+        public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, IDictionary<string, object> parameters, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+            where TModel : class
+            => Task.Run(async () => await query.GetAsync(mapper, options, parameters, handleNullPropagation)).Result;
+
+        /// <summary>
+        /// Get
+        /// </summary>
+        /// <typeparam name="TModel"></typeparam>
+        /// <typeparam name="TData"></typeparam>
+        /// <param name="query"></param>
+        /// <param name="mapper"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
         public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
             where TModel : class
-            => Task.Run(async () => await query.GetAsync(mapper, options, handleNullPropagation)).Result;
+            => Task.Run(async () => await query.GetAsync(mapper, options, null, handleNullPropagation)).Result;
 
         /// <summary>
         /// GetAsync
@@ -34,14 +47,14 @@ namespace AutoMapper.AspNet.OData
         /// <param name="mapper"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, IDictionary<string, object> parameters, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
             where TModel : class
         {
             Expression<Func<TModel, object>>[] includeExpressions = options.SelectExpand.GetIncludes().BuildIncludes<TModel>().ToArray();
             Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
 
-            ICollection<TModel> collection = await query.GetAsync(mapper, filter, queryableExpression, includeExpressions);
+            ICollection<TModel> collection = await query.GetAsync(mapper, filter, queryableExpression, includeExpressions, parameters);
 
             return collection;
         }
@@ -92,11 +105,13 @@ namespace AutoMapper.AspNet.OData
         /// <param name="filter"></param>
         /// <param name="queryFunc"></param>
         /// <param name="includeProperties"></param>
+        /// <param name="parameters"></param>
         /// <returns></returns>
         public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper,
             Expression<Func<TModel, bool>> filter = null,
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryFunc = null,
-            IEnumerable<Expression<Func<TModel, object>>> includeProperties = null)
+            IEnumerable<Expression<Func<TModel, object>>> includeProperties = null,
+            IDictionary<string, object> parameters = null)
         {
             //Map the expressions
             Expression<Func<TData, bool>> f = mapper.MapExpression<Expression<Func<TData, bool>>>(filter);
@@ -112,8 +127,15 @@ namespace AutoMapper.AspNet.OData
             //Call the store
             ICollection<TData> result = mappedQueryFunc != null ? await mappedQueryFunc(query).ToListAsync() : await query.ToListAsync();
 
-            //Map and return the data
-            return mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(result).ToList();
+            //Map and return the data            
+            if (parameters == null)
+                return mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(result).ToList();
+
+            return mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(result, o =>
+            {
+                foreach (var key in parameters.Keys)
+                    o.Items[key] = parameters[key];
+            }).ToList();
         }
 
         /// <summary>

--- a/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
@@ -20,23 +20,12 @@ namespace AutoMapper.AspNet.OData
         /// <param name="query"></param>
         /// <param name="mapper"></param>
         /// <param name="options"></param>
+        /// <param name="handleNullPropagation"></param>
+        /// <param name="opts"></param>
         /// <returns></returns>
-        public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, IDictionary<string, object> parameters, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+        public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default, Action<IMappingOperationOptions<IEnumerable<TData>, IEnumerable<TModel>>> opts = null)
             where TModel : class
-            => Task.Run(async () => await query.GetAsync(mapper, options, parameters, handleNullPropagation)).Result;
-
-        /// <summary>
-        /// Get
-        /// </summary>
-        /// <typeparam name="TModel"></typeparam>
-        /// <typeparam name="TData"></typeparam>
-        /// <param name="query"></param>
-        /// <param name="mapper"></param>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
-            where TModel : class
-            => Task.Run(async () => await query.GetAsync(mapper, options, null, handleNullPropagation)).Result;
+            => Task.Run(async () => await query.GetAsync(mapper, options, handleNullPropagation, opts)).Result;
 
         /// <summary>
         /// GetAsync
@@ -46,15 +35,21 @@ namespace AutoMapper.AspNet.OData
         /// <param name="query"></param>
         /// <param name="mapper"></param>
         /// <param name="options"></param>
+        /// <param name="handleNullPropagation"></param>
+        /// <param name="opts"></param>
         /// <returns></returns>
-        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, IDictionary<string, object> parameters, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, 
+            IMapper mapper, 
+            ODataQueryOptions<TModel> options, 
+            HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default, 
+            Action<IMappingOperationOptions<IEnumerable<TData>, IEnumerable<TModel>>> opts = null)
             where TModel : class
         {
             Expression<Func<TModel, object>>[] includeExpressions = options.SelectExpand.GetIncludes().BuildIncludes<TModel>().ToArray();
             Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
 
-            ICollection<TModel> collection = await query.GetAsync(mapper, filter, queryableExpression, includeExpressions, parameters);
+            ICollection<TModel> collection = await query.GetAsync(mapper, filter, queryableExpression, includeExpressions, opts);
 
             return collection;
         }
@@ -88,12 +83,14 @@ namespace AutoMapper.AspNet.OData
         /// <param name="filter"></param>
         /// <param name="queryFunc"></param>
         /// <param name="includeProperties"></param>
+        /// <param name="opts"></param>
         /// <returns></returns>
         public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper,
             Expression<Func<TModel, bool>> filter = null,
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryFunc = null,
-            IEnumerable<Expression<Func<TModel, object>>> includeProperties = null)
-            => Task.Run(async () => await query.GetAsync(mapper, filter, queryFunc, includeProperties)).Result;
+            IEnumerable<Expression<Func<TModel, object>>> includeProperties = null,
+            Action<IMappingOperationOptions<IEnumerable<TData>, IEnumerable<TModel>>> opts = null)
+            => Task.Run(async () => await query.GetAsync(mapper, filter, queryFunc, includeProperties, opts)).Result;
 
         /// <summary>
         /// GetAsync
@@ -105,13 +102,13 @@ namespace AutoMapper.AspNet.OData
         /// <param name="filter"></param>
         /// <param name="queryFunc"></param>
         /// <param name="includeProperties"></param>
-        /// <param name="parameters"></param>
+        /// <param name="opts"></param>
         /// <returns></returns>
         public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper,
             Expression<Func<TModel, bool>> filter = null,
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryFunc = null,
             IEnumerable<Expression<Func<TModel, object>>> includeProperties = null,
-            IDictionary<string, object> parameters = null)
+            Action<IMappingOperationOptions<IEnumerable<TData>, IEnumerable<TModel>>> opts = null)
         {
             //Map the expressions
             Expression<Func<TData, bool>> f = mapper.MapExpression<Expression<Func<TData, bool>>>(filter);
@@ -128,14 +125,9 @@ namespace AutoMapper.AspNet.OData
             ICollection<TData> result = mappedQueryFunc != null ? await mappedQueryFunc(query).ToListAsync() : await query.ToListAsync();
 
             //Map and return the data            
-            if (parameters == null)
-                return mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(result).ToList();
-
-            return mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(result, o =>
-            {
-                foreach (var key in parameters.Keys)
-                    o.Items[key] = parameters[key];
-            }).ToList();
+            return opts == null
+                ? mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(result).ToList()
+                : mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(result, opts).ToList();
         }
 
         /// <summary>

--- a/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
@@ -21,9 +21,22 @@ namespace AutoMapper.AspNet.OData
         /// <param name="mapper"></param>
         /// <param name="options"></param>
         /// <returns></returns>
+        public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, IDictionary<string, object> parameters, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+            where TModel : class
+            => Task.Run(async () => await query.GetAsync(mapper, options, parameters, handleNullPropagation)).Result;
+
+        /// <summary>
+        /// Get
+        /// </summary>
+        /// <typeparam name="TModel"></typeparam>
+        /// <typeparam name="TData"></typeparam>
+        /// <param name="query"></param>
+        /// <param name="mapper"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
         public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
             where TModel : class
-            => Task.Run(async () => await query.GetAsync(mapper, options, handleNullPropagation)).Result;
+            => Task.Run(async () => await query.GetAsync(mapper, options, null, handleNullPropagation)).Result;
 
         /// <summary>
         /// GetAsync
@@ -34,14 +47,14 @@ namespace AutoMapper.AspNet.OData
         /// <param name="mapper"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, IDictionary<string, object> parameters, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
             where TModel : class
         {
             ICollection<Expression<Func<IQueryable<TModel>, IIncludableQueryable<TModel, object>>>> includeExpressions = options.SelectExpand.GetIncludes().BuildIncludesExpressionCollection<TModel>()?.ToList();
             Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
 
-            ICollection<TModel> collection = await query.GetAsync(mapper, filter, queryableExpression, includeExpressions);
+            ICollection<TModel> collection = await query.GetAsync(mapper, filter, queryableExpression, includeExpressions, parameters);
 
             return collection;
         }
@@ -83,11 +96,13 @@ namespace AutoMapper.AspNet.OData
         /// <param name="filter"></param>
         /// <param name="queryFunc"></param>
         /// <param name="includeProperties"></param>
+        /// <param name="parameters"></param>
         /// <returns></returns>
         public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper,
             Expression<Func<TModel, bool>> filter = null,
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryFunc = null,
-            ICollection<Expression<Func<IQueryable<TModel>, IIncludableQueryable<TModel, object>>>> includeProperties = null)
+            ICollection<Expression<Func<IQueryable<TModel>, IIncludableQueryable<TModel, object>>>> includeProperties = null,
+            IDictionary<string, object> parameters = null)
         {
             //Map the expressions
             Expression<Func<TData, bool>> f = mapper.MapExpression<Expression<Func<TData, bool>>>(filter);
@@ -104,7 +119,14 @@ namespace AutoMapper.AspNet.OData
             ICollection<TData> result = mappedQueryFunc != null ? await mappedQueryFunc(query).ToListAsync() : await query.ToListAsync();
 
             //Map and return the data
-            return mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(result).ToList();
+            if (parameters == null)
+                return mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(result).ToList();
+
+            return mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(result, o =>
+            {
+                foreach (var key in parameters.Keys)
+                    o.Items[key] = parameters[key];
+            }).ToList();
         }
 
         /// <summary>

--- a/AutoMapper.OData.EFCore.Tests/AllTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/AllTests.cs
@@ -223,6 +223,7 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
+                    null,
                     HandleNullPropagationOption.False
                 );
             }

--- a/AutoMapper.OData.EFCore.Tests/AllTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/AllTests.cs
@@ -212,7 +212,16 @@ namespace AutoMapper.OData.EFCore.Tests
             {
                 { "parameter", parameterValue}
             };
-            Test(await Get<CoreBuilding, TBuilding>("/corebuilding", parameters));
+            Test
+            (
+                await Get<CoreBuilding, TBuilding>
+                (
+                    "/corebuilding",
+                    opts => parameters.Keys
+                            .ToList()
+                            .ForEach(key => opts.Items[key] = parameters[key])
+                )
+            );
 
             void Test(ICollection<CoreBuilding> collection)
             {
@@ -231,7 +240,7 @@ namespace AutoMapper.OData.EFCore.Tests
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, IDictionary<string, object> parameters = null) where TModel : class where TData : class
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, Action<IMappingOperationOptions<IEnumerable<TData>, IEnumerable<TModel>>> opts = null) where TModel : class where TData : class
         {
             return await DoGet
             (
@@ -250,8 +259,8 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    parameters,
-                    HandleNullPropagationOption.False
+                    HandleNullPropagationOption.False,
+                    opts
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/AllTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/AllTests.cs
@@ -204,7 +204,34 @@ namespace AutoMapper.OData.EFCore.Tests
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query) where TModel : class where TData : class
+        [Fact]
+        public async void Building_with_parameters_are_mapped()
+        {
+            string parameterValue = Guid.NewGuid().ToString();
+            var parameters = new Dictionary<string, object>
+            {
+                { "parameter", parameterValue}
+            };
+            Test(await Get<CoreBuilding, TBuilding>("/corebuilding", parameters));
+
+            void Test(ICollection<CoreBuilding> collection)
+            {
+                Assert.Same(parameterValue, collection.First().Parameter);
+            }
+        }
+
+        [Fact]
+        public async void Building_without_parameters_arent_mapped()
+        {
+            Test(await Get<CoreBuilding, TBuilding>("/corebuilding"));
+
+            void Test(ICollection<CoreBuilding> collection)
+            {
+                Assert.Same("unknown", collection.First().Parameter);
+            }
+        }
+
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, IDictionary<string, object> parameters = null) where TModel : class where TData : class
         {
             return await DoGet
             (
@@ -223,7 +250,7 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    null,
+                    parameters,
                     HandleNullPropagationOption.False
                 );
             }

--- a/AutoMapper.OData.EFCore.Tests/Mappings/CoreBuildingMappings.cs
+++ b/AutoMapper.OData.EFCore.Tests/Mappings/CoreBuildingMappings.cs
@@ -1,4 +1,5 @@
-﻿using DAL.EFCore;
+﻿using System.Collections.Generic;
+using DAL.EFCore;
 using Domain.OData;
 
 namespace AutoMapper.OData.EFCore.Tests.Mappings
@@ -12,11 +13,21 @@ namespace AutoMapper.OData.EFCore.Tests.Mappings
                 .ForMember(d => d.Name, o => o.MapFrom(s => s.LongName))
                 .ForMember(d => d.Builder, o => o.MapFrom(s => s.Builder))
                 .ForMember(d => d.Tenant, o => o.MapFrom(s => s.Mandator))
-                .ForMember(d => d.Parameter, o => o.MapFrom((s, d, m, c) => c.Items.ContainsKey("parameter") ? (string)c.Items["parameter"] : "unknown"))
+                .ForMember(d => d.Parameter, o => o.MapFrom((s, d, m, c) => (string)c.Items.GetOrDefault("parameter", "unknown")))
+                //.ForMember(d => d.Parameter, o => o.MapFrom(new VR(), s => s.LongName))
+                //.ForMember(d => d.Parameter, o => o.MapFrom(s => "a"))
                 .ForAllOtherMembers(o => o.Ignore());
 
             CreateMap<TBuilder, OpsBuilder>();
             CreateMap<TCity, OpsCity>();
+        }
+    }
+
+    public static class DictionaryExtensions
+    {
+        public static TValue GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value = default(TValue))
+        {
+            return dictionary.TryGetValue(key, out TValue v) ? v : value;
         }
     }
 }

--- a/AutoMapper.OData.EFCore.Tests/Mappings/CoreBuildingMappings.cs
+++ b/AutoMapper.OData.EFCore.Tests/Mappings/CoreBuildingMappings.cs
@@ -12,6 +12,7 @@ namespace AutoMapper.OData.EFCore.Tests.Mappings
                 .ForMember(d => d.Name, o => o.MapFrom(s => s.LongName))
                 .ForMember(d => d.Builder, o => o.MapFrom(s => s.Builder))
                 .ForMember(d => d.Tenant, o => o.MapFrom(s => s.Mandator))
+                .ForMember(d => d.Parameter, o => o.MapFrom((s, d, m, c) => c.Items.ContainsKey("parameter") ? (string)c.Items["parameter"] : "unknown"))
                 .ForAllOtherMembers(o => o.Ignore());
 
             CreateMap<TBuilder, OpsBuilder>();

--- a/Domain.OData/CoreBuilding.cs
+++ b/Domain.OData/CoreBuilding.cs
@@ -10,5 +10,6 @@ namespace Domain.OData
         public string Name { get; set; }
         public OpsBuilder Builder { get; set; }
         public OpsTenant Tenant { get; set; }
+        public string Parameter { get; set; }
     }
 }


### PR DESCRIPTION
Adding the ability to add pass in parameters to map expression.

Similar to:

* AutoMapper.Extensions.ExpressionMapping
``` ISourceInjectedQueryable<TDestination> For<TDestination>(IDictionary<string, object> parameters, params string[] membersToExpand); ```

* AutoMapper.QueryableExtensions
``` IQueryable<TDestination> ProjectTo<TDestination>(this IQueryable source, IConfigurationProvider configuration, IDictionary<string, object> parameters, params string[] membersToExpand) ```