### PR TITLE
Fix for InvalidOperationException on "Get" for EF 6 (expanding literal types)

### DIFF
--- a/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
@@ -37,7 +37,7 @@ namespace AutoMapper.AspNet.OData
         public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
             where TModel : class
         {
-            List<Expression<Func<TModel, object>>> includeExpressions = options.SelectExpand.GetExpansions().BuildIncludes<TModel>(options.SelectExpand.GetSelects()).ToList();
+            List<Expression<Func<TModel, object>>> includeExpressions = options.SelectExpand.GetIncludes().BuildIncludes<TModel>().ToList();
             Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
             Expression<Func<IQueryable<TModel>, long>> countExpression = LinqExtensions.GetCountExpression<TModel>(filter);
@@ -120,7 +120,7 @@ namespace AutoMapper.AspNet.OData
                 query = includes.Aggregate(query, (q, next) => q.Include(next));
 
             //Call the store
-            ICollection<TData> result = mappedQueryFunc != null ? await mappedQueryFunc(query).ToListAsync() : await query.ToListAsync();
+            ICollection<TData> result = mappedQueryFunc != null ? mappedQueryFunc(query).ToList() : query.ToList();
 
             //Map and return the data
             return mapper.Map<IEnumerable<TData>, IEnumerable<TModel>>(result).ToList();

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Authors>BlaiseD</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>1.0.4-preview01</VersionPrefix>
+    <VersionPrefix>1.0.4-preview02</VersionPrefix>
     <WarningsAsErrors>true</WarningsAsErrors>
     <NoWarn>$(NoWarn);1701;1702;1591</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Fix for InvalidOperationException on "Get" for EF 6 (expanding literal types)