### PR TITLE
AspNetCore.OData.EFCore - unnecessary dependency to SQLServer

### DIFF
--- a/AutoMapper.AspNetCore.OData.EFCore/AutoMapper.AspNetCore.OData.EFCore.csproj
+++ b/AutoMapper.AspNetCore.OData.EFCore/AutoMapper.AspNetCore.OData.EFCore.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[4.0.1,5.0.0)" />
     <PackageReference Include="LogicBuilder.Expressions.Utils" Version="4.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.4.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="MinVer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The package AutoMapper.AspNetCore.OData.EFCore depends on Microsoft.EntityFrameworkCore.SqlServer but there is no need to use the SQLServer package of EFCore, Microsoft.EntityFrameworkCore would be sufficient. 

This PR replaces the package reference
`Microsoft.EntityFrameworkCore.SqlServer` with `Microsoft.EntityFrameworkCore`

