### PR TITLE
pass QuerySettings in GetAsync/Get/GetQuery

### DIFF
--- a/AutoMapper.AspNet.OData.EF6/AutoMapper.AspNet.OData.EF6.csproj
+++ b/AutoMapper.AspNet.OData.EF6/AutoMapper.AspNet.OData.EF6.csproj
@@ -25,6 +25,7 @@
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\FilterHelper.cs" Link="FilterHelper.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\LinqExtensions.cs" Link="LinqExtensions.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Properties\Resources.Designer.cs" Link="Properties\Resources.Designer.cs" />
+    <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\QuerySettings.cs" Link="QuerySettings.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\TypeExtensions.cs" Link="TypeExtensions.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Visitors\ChildCollectionFilterUpdater.cs" Link="Visitors\ChildCollectionFilterUpdater.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Visitors\ChildCollectionOrderByUpdater.cs" Link="Visitors\ChildCollectionOrderByUpdater.cs" />

--- a/AutoMapper.AspNet.OData.EF6/AutoMapper.AspNet.OData.EF6.csproj
+++ b/AutoMapper.AspNet.OData.EF6/AutoMapper.AspNet.OData.EF6.csproj
@@ -6,7 +6,7 @@
     <PackageId>AutoMapper.AspNet.OData.EF6</PackageId>
     <Description>Creates LINQ expressions from ODataQueryOptions and executes the query.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>Adding filtering and sorting for child collections.</PackageReleaseNotes>
+    <PackageReleaseNotes>Incorporating v.latest from AutoMapper.Extensions.ExpressionMapping</PackageReleaseNotes>
     <PackageTags>linq expressions odata ef</PackageTags>
     <PackageIconUrl>https://s3.amazonaws.com/automapper/icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/AutoMapper/AutoMapper.Extensions.OData</RepositoryUrl>
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[4.0.1,5.0.0)" />
+    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[4.0.2,5.0.0)" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
     <PackageReference Include="LogicBuilder.Expressions.Utils" Version="4.0.2" />
     <PackageReference Include="Microsoft.AspNet.OData" Version="7.4.1" />

--- a/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
+++ b/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
@@ -6,7 +6,7 @@
     <PackageId>AutoMapper.AspNetCore.OData.EF6</PackageId>
     <Description>Creates LINQ expressions from ODataQueryOptions and executes the query.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>Adding filtering and sorting for child collections.</PackageReleaseNotes>
+    <PackageReleaseNotes>Incorporating v.latest from AutoMapper.Extensions.ExpressionMapping</PackageReleaseNotes>
     <PackageTags>linq expressions odata efcore</PackageTags>
     <PackageIconUrl>https://s3.amazonaws.com/automapper/icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/AutoMapper/AutoMapper.Extensions.OData</RepositoryUrl>
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[4.0.1,5.0.0)" />
+    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[4.0.2,5.0.0)" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
     <PackageReference Include="LogicBuilder.Expressions.Utils" Version="4.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.4.1" />

--- a/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
+++ b/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
@@ -25,6 +25,7 @@
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\LinqExtensions.cs" Link="LinqExtensions.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\ODataQueryOptionsExtensions.cs" Link="ODataQueryOptionsExtensions.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Properties\Resources.Designer.cs" Link="Properties\Resources.Designer.cs" />
+    <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\QuerySettings.cs" Link="QuerySettings.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\TypeExtensions.cs" Link="TypeExtensions.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Visitors\ChildCollectionFilterUpdater.cs" Link="Visitors\ChildCollectionFilterUpdater.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Visitors\ChildCollectionOrderByUpdater.cs" Link="Visitors\ChildCollectionOrderByUpdater.cs" />

--- a/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
@@ -21,10 +21,26 @@ namespace AutoMapper.AspNet.OData
         /// <param name="query"></param>
         /// <param name="mapper"></param>
         /// <param name="options"></param>
+        /// <param name="handleNullPropagation"></param>
         /// <returns></returns>
         public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
             where TModel : class
             => Task.Run(async () => await query.GetAsync(mapper, options, handleNullPropagation)).Result;
+
+        /// <summary>
+        /// Get
+        /// </summary>
+        /// <typeparam name="TModel"></typeparam>
+        /// <typeparam name="TData"></typeparam>
+        /// <param name="query"></param>
+        /// <param name="mapper"></param>
+        /// <param name="options"></param>
+        /// <param name="querySettings"></param>
+        /// <returns></returns>
+        public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings)
+            where TModel : class
+            => Task.Run(async () => await query.GetAsync(mapper, options, querySettings)).Result;
+
 
         /// <summary>
         /// GetAsync
@@ -34,12 +50,32 @@ namespace AutoMapper.AspNet.OData
         /// <param name="query"></param>
         /// <param name="mapper"></param>
         /// <param name="options"></param>
+        /// <param name="handleNullPropagation"></param>
         /// <returns></returns>
-        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+        public static Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query,
+            IMapper mapper, ODataQueryOptions<TModel> options,
+            HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+            where TModel : class
+        {
+            return GetAsync<TModel, TData>(query, mapper, options,
+                new ODataQuerySettings {HandleNullPropagation = handleNullPropagation});
+        }
+
+        /// <summary>
+        /// GetAsync
+        /// </summary>
+        /// <typeparam name="TModel"></typeparam>
+        /// <typeparam name="TData"></typeparam>
+        /// <param name="query"></param>
+        /// <param name="mapper"></param>
+        /// <param name="options"></param>
+        /// <param name="querySettings"></param>
+        /// <returns></returns>
+        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings = null)
             where TModel : class
         {
             List<Expression<Func<TModel, object>>> includeExpressions = options.SelectExpand.GetIncludes().BuildIncludes<TModel>().ToList();
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
+            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings);
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
             Expression<Func<IQueryable<TModel>, long>> countExpression = LinqExtensions.GetCountExpression<TModel>(filter);
 
@@ -60,8 +96,27 @@ namespace AutoMapper.AspNet.OData
         /// <param name="query"></param>
         /// <param name="mapper"></param>
         /// <param name="options"></param>
+        /// <param name="handleNullPropagation"></param>
         /// <returns></returns>
-        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+        public static Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query,
+            IMapper mapper, ODataQueryOptions<TModel> options,
+            HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+            where TModel : class
+        {
+            return GetQueryAsync(query, mapper, options, new ODataQuerySettings{HandleNullPropagation = handleNullPropagation});
+        }
+
+        /// <summary>
+        /// GetQueryAsync
+        /// </summary>
+        /// <typeparam name="TModel"></typeparam>
+        /// <typeparam name="TData"></typeparam>
+        /// <param name="query"></param>
+        /// <param name="mapper"></param>
+        /// <param name="options"></param>
+        /// <param name="querySettings"></param>
+        /// <returns></returns>
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings = null)
             where TModel : class
         {
             var expansions = options.SelectExpand.GetExpansions(typeof(TModel));
@@ -71,7 +126,7 @@ namespace AutoMapper.AspNet.OData
             )
             .ToList();
 
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
+            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings);
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
             Expression<Func<IQueryable<TModel>, long>> countExpression = LinqExtensions.GetCountExpression<TModel>(filter);
 

--- a/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
@@ -37,7 +37,7 @@ namespace AutoMapper.AspNet.OData
         /// <param name="options"></param>
         /// <param name="querySettings"></param>
         /// <returns></returns>
-        public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings)
+        public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings)
             where TModel : class
             => Task.Run(async () => await query.GetAsync(mapper, options, querySettings)).Result;
 
@@ -58,7 +58,7 @@ namespace AutoMapper.AspNet.OData
             where TModel : class
         {
             return GetAsync<TModel, TData>(query, mapper, options,
-                new ODataQuerySettings {HandleNullPropagation = handleNullPropagation});
+                new QuerySettings {HandleNullPropagation = handleNullPropagation});
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace AutoMapper.AspNet.OData
         /// <param name="options"></param>
         /// <param name="querySettings"></param>
         /// <returns></returns>
-        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings = null)
+        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
             List<Expression<Func<TModel, object>>> includeExpressions = options.SelectExpand.GetIncludes().BuildIncludes<TModel>().ToList();
@@ -103,7 +103,7 @@ namespace AutoMapper.AspNet.OData
             HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
             where TModel : class
         {
-            return GetQueryAsync(query, mapper, options, new ODataQuerySettings{HandleNullPropagation = handleNullPropagation});
+            return GetQueryAsync(query, mapper, options, new QuerySettings{HandleNullPropagation = handleNullPropagation});
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace AutoMapper.AspNet.OData
         /// <param name="options"></param>
         /// <param name="querySettings"></param>
         /// <returns></returns>
-        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings = null)
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
             var expansions = options.SelectExpand.GetExpansions(typeof(TModel));

--- a/AutoMapper.AspNetCore.OData.EFCore/AutoMapper.AspNetCore.OData.EFCore.csproj
+++ b/AutoMapper.AspNetCore.OData.EFCore/AutoMapper.AspNetCore.OData.EFCore.csproj
@@ -6,7 +6,7 @@
     <PackageId>AutoMapper.AspNetCore.OData.EFCore</PackageId>
     <Description>Creates LINQ expressions from ODataQueryOptions and executes the query.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>Adding filtering and sorting for child collections.</PackageReleaseNotes>
+    <PackageReleaseNotes>Incorporating v.latest from AutoMapper.Extensions.ExpressionMapping</PackageReleaseNotes>
     <PackageTags>linq expressions odata efcore</PackageTags>
     <PackageIconUrl>https://s3.amazonaws.com/automapper/icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/AutoMapper/AutoMapper.Extensions.OData</RepositoryUrl>
@@ -18,10 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[4.0.1,5.0.0)" />
+    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[4.0.2,5.0.0)" />
     <PackageReference Include="LogicBuilder.Expressions.Utils" Version="4.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.4.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="MinVer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -21,22 +21,13 @@ namespace AutoMapper.AspNet.OData
         /// <typeparam name="T"></typeparam>
         /// <param name="filterOption"></param>
         /// <returns></returns>
-        [Obsolete("ToFilterExpression with handleNullPropagation parameter is obsolete. Use ToFilterExpression with querySettings parameter.")]
         public static Expression<Func<T, bool>> ToFilterExpression<T>(this FilterQueryOption filterOption, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
-        {
-            return ToFilterExpression<T>(filterOption,
-                new QuerySettings {HandleNullPropagation = handleNullPropagation});
-        }
-
-        public static Expression<Func<T, bool>> ToFilterExpression<T>(this FilterQueryOption filterOption, QuerySettings querySettings = null)
         {
             if (filterOption == null)
                 return null;
 
-            querySettings ??= new QuerySettings();
-
             IQueryable queryable = Enumerable.Empty<T>().AsQueryable();
-            queryable = filterOption.ApplyTo(queryable, querySettings.AsODataQuerySettings());
+            queryable = filterOption.ApplyTo(queryable, new ODataQuerySettings() { HandleNullPropagation = handleNullPropagation });
             MethodCallExpression whereMethodCallExpression = (MethodCallExpression)queryable.Expression;
 
             return (Expression<Func<T, bool>>)(whereMethodCallExpression.Arguments[1].Unquote() as LambdaExpression);

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -25,18 +25,18 @@ namespace AutoMapper.AspNet.OData
         public static Expression<Func<T, bool>> ToFilterExpression<T>(this FilterQueryOption filterOption, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
         {
             return ToFilterExpression<T>(filterOption,
-                new ODataQuerySettings {HandleNullPropagation = handleNullPropagation});
+                new QuerySettings {HandleNullPropagation = handleNullPropagation});
         }
 
-        public static Expression<Func<T, bool>> ToFilterExpression<T>(this FilterQueryOption filterOption, ODataQuerySettings querySettings = null)
+        public static Expression<Func<T, bool>> ToFilterExpression<T>(this FilterQueryOption filterOption, QuerySettings querySettings = null)
         {
             if (filterOption == null)
                 return null;
 
-            querySettings ??= new ODataQuerySettings();
+            querySettings ??= new QuerySettings();
 
             IQueryable queryable = Enumerable.Empty<T>().AsQueryable();
-            queryable = filterOption.ApplyTo(queryable, querySettings);
+            queryable = filterOption.ApplyTo(queryable, querySettings.AsODataQuerySettings());
             MethodCallExpression whereMethodCallExpression = (MethodCallExpression)queryable.Expression;
 
             return (Expression<Func<T, bool>>)(whereMethodCallExpression.Arguments[1].Unquote() as LambdaExpression);

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -21,13 +21,22 @@ namespace AutoMapper.AspNet.OData
         /// <typeparam name="T"></typeparam>
         /// <param name="filterOption"></param>
         /// <returns></returns>
+        [Obsolete("ToFilterExpression with handleNullPropagation parameter is obsolete. Use ToFilterExpression with querySettings parameter.")]
         public static Expression<Func<T, bool>> ToFilterExpression<T>(this FilterQueryOption filterOption, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+        {
+            return ToFilterExpression<T>(filterOption,
+                new ODataQuerySettings {HandleNullPropagation = handleNullPropagation});
+        }
+
+        public static Expression<Func<T, bool>> ToFilterExpression<T>(this FilterQueryOption filterOption, ODataQuerySettings querySettings)
         {
             if (filterOption == null)
                 return null;
 
+            querySettings ??= new ODataQuerySettings();
+
             IQueryable queryable = Enumerable.Empty<T>().AsQueryable();
-            queryable = filterOption.ApplyTo(queryable, new ODataQuerySettings() { HandleNullPropagation = handleNullPropagation });
+            queryable = filterOption.ApplyTo(queryable, querySettings);
             MethodCallExpression whereMethodCallExpression = (MethodCallExpression)queryable.Expression;
 
             return (Expression<Func<T, bool>>)(whereMethodCallExpression.Arguments[1].Unquote() as LambdaExpression);

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -28,7 +28,7 @@ namespace AutoMapper.AspNet.OData
                 new ODataQuerySettings {HandleNullPropagation = handleNullPropagation});
         }
 
-        public static Expression<Func<T, bool>> ToFilterExpression<T>(this FilterQueryOption filterOption, ODataQuerySettings querySettings)
+        public static Expression<Func<T, bool>> ToFilterExpression<T>(this FilterQueryOption filterOption, ODataQuerySettings querySettings = null)
         {
             if (filterOption == null)
                 return null;

--- a/AutoMapper.AspNetCore.OData.EFCore/QuerySettings.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QuerySettings.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNet.OData.Query;
+
+namespace AutoMapper.AspNet.OData
+{
+    /// <summary>
+    /// This class describes the settings to use during query composition.
+    /// </summary>
+    public class QuerySettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating how null propagation should
+        /// be handled during query composition.
+        /// </summary>
+        /// <value>
+        /// The default is <see cref="F:Microsoft.AspNet.OData.Query.HandleNullPropagationOption.Default" />.
+        /// </value>
+        public HandleNullPropagationOption HandleNullPropagation { get; set; } = HandleNullPropagationOption.Default;
+
+
+        internal ODataQuerySettings AsODataQuerySettings()
+        {
+            return new ODataQuerySettings
+            {
+                HandleNullPropagation = HandleNullPropagation
+            };
+        }
+    }
+}

--- a/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
@@ -20,24 +20,13 @@ namespace AutoMapper.AspNet.OData
 
         public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
-            => Task.Run(async () => await query.GetAsync(mapper, options, querySettings)).Result;
+            => query.Get(mapper, options, querySettings == null ? HandleNullPropagationOption.Default : querySettings.HandleNullPropagation);
 
-
-        public static Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query,
-            IMapper mapper, ODataQueryOptions<TModel> options,
-            HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
-            where TModel : class
-        {
-            return GetAsync(query, mapper, options,
-                new QuerySettings {HandleNullPropagation = handleNullPropagation});
-        }
-
-
-        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
+        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
             where TModel : class
         {
             ICollection<Expression<Func<IQueryable<TModel>, IIncludableQueryable<TModel, object>>>> includeExpressions = options.SelectExpand.GetIncludes().BuildIncludesExpressionCollection<TModel>()?.ToList();
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings);
+            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
             Expression<Func<IQueryable<TModel>, long>> countExpression = LinqExtensions.GetCountExpression<TModel>(filter);
 
@@ -48,16 +37,11 @@ namespace AutoMapper.AspNet.OData
             return await query.GetAsync(mapper, filter, queryableExpression, includeExpressions);
         }
 
-        public static Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query,
-            IMapper mapper, ODataQueryOptions<TModel> options,
-            HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
-        {
-            return GetQueryAsync(query, mapper, options,
-                new QuerySettings {HandleNullPropagation = handleNullPropagation});
-        }
+            => await query.GetAsync(mapper, options, querySettings == null ? HandleNullPropagationOption.Default : querySettings.HandleNullPropagation);
 
-        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
             where TModel : class
         {
             var expansions = options.SelectExpand.GetExpansions(typeof(TModel));
@@ -67,7 +51,7 @@ namespace AutoMapper.AspNet.OData
             )
             .ToList();
 
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings);
+            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
             Expression<Func<IQueryable<TModel>, long>> countExpression = LinqExtensions.GetCountExpression<TModel>(filter);
 
@@ -79,6 +63,10 @@ namespace AutoMapper.AspNet.OData
 
             return queryable.UpdateQueryableExpression(expansions);
         }
+
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
+            where TModel : class
+            => await query.GetQueryAsync(mapper, options, querySettings == null ? HandleNullPropagationOption.Default : querySettings.HandleNullPropagation);
 
         public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper,
             Expression<Func<TModel, bool>> filter = null,

--- a/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
@@ -18,7 +18,7 @@ namespace AutoMapper.AspNet.OData
             where TModel : class
             => Task.Run(async () => await query.GetAsync(mapper, options, handleNullPropagation)).Result;
 
-        public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings = null)
+        public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
             => Task.Run(async () => await query.GetAsync(mapper, options, querySettings)).Result;
 
@@ -29,11 +29,11 @@ namespace AutoMapper.AspNet.OData
             where TModel : class
         {
             return GetAsync(query, mapper, options,
-                new ODataQuerySettings {HandleNullPropagation = handleNullPropagation});
+                new QuerySettings {HandleNullPropagation = handleNullPropagation});
         }
 
 
-        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings = null)
+        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
             ICollection<Expression<Func<IQueryable<TModel>, IIncludableQueryable<TModel, object>>>> includeExpressions = options.SelectExpand.GetIncludes().BuildIncludesExpressionCollection<TModel>()?.ToList();
@@ -54,10 +54,10 @@ namespace AutoMapper.AspNet.OData
             where TModel : class
         {
             return GetQueryAsync(query, mapper, options,
-                new ODataQuerySettings {HandleNullPropagation = handleNullPropagation});
+                new QuerySettings {HandleNullPropagation = handleNullPropagation});
         }
 
-        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings = null)
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
             var expansions = options.SelectExpand.GetExpansions(typeof(TModel));

--- a/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
@@ -18,11 +18,26 @@ namespace AutoMapper.AspNet.OData
             where TModel : class
             => Task.Run(async () => await query.GetAsync(mapper, options, handleNullPropagation)).Result;
 
-        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+        public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings = null)
+            where TModel : class
+            => Task.Run(async () => await query.GetAsync(mapper, options, querySettings)).Result;
+
+
+        public static Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query,
+            IMapper mapper, ODataQueryOptions<TModel> options,
+            HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+            where TModel : class
+        {
+            return GetAsync(query, mapper, options,
+                new ODataQuerySettings {HandleNullPropagation = handleNullPropagation});
+        }
+
+
+        public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings = null)
             where TModel : class
         {
             ICollection<Expression<Func<IQueryable<TModel>, IIncludableQueryable<TModel, object>>>> includeExpressions = options.SelectExpand.GetIncludes().BuildIncludesExpressionCollection<TModel>()?.ToList();
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
+            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings);
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
             Expression<Func<IQueryable<TModel>, long>> countExpression = LinqExtensions.GetCountExpression<TModel>(filter);
 
@@ -33,7 +48,16 @@ namespace AutoMapper.AspNet.OData
             return await query.GetAsync(mapper, filter, queryableExpression, includeExpressions);
         }
 
-        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+        public static Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query,
+            IMapper mapper, ODataQueryOptions<TModel> options,
+            HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+            where TModel : class
+        {
+            return GetQueryAsync(query, mapper, options,
+                new ODataQuerySettings {HandleNullPropagation = handleNullPropagation});
+        }
+
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, ODataQuerySettings querySettings = null)
             where TModel : class
         {
             var expansions = options.SelectExpand.GetExpansions(typeof(TModel));
@@ -43,7 +67,7 @@ namespace AutoMapper.AspNet.OData
             )
             .ToList();
 
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
+            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings);
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
             Expression<Func<IQueryable<TModel>, long>> countExpression = LinqExtensions.GetCountExpression<TModel>(filter);
 

--- a/AutoMapper.OData.EFCore.Tests/GetQuerySelectTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQuerySelectTests.cs
@@ -149,7 +149,7 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
+                    new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/GetQuerySelectTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQuerySelectTests.cs
@@ -149,7 +149,7 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    HandleNullPropagationOption.False
+                    new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -590,7 +590,7 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    HandleNullPropagationOption.False
+                    new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
                 );
             }
         }
@@ -617,7 +617,7 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    HandleNullPropagationOption.False
+                    new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -112,19 +112,6 @@ namespace AutoMapper.OData.EFCore.Tests
         }
 
         [Fact]
-        public async void OpsTenantExpandBuildingsNoFilterAndOrderByWithPageSize()
-        {
-            Test(await GetWithPageSize<OpsTenant, TMandator>("/opstenant?$top=5&$expand=Buildings&$orderby=Name desc",1));
-
-            void Test(ICollection<OpsTenant> collection)
-            {
-                Assert.Equal(1, collection.Count);
-                Assert.Equal(3, collection.First().Buildings.Count);
-                Assert.Equal("Two", collection.First().Name);
-            }
-        }
-
-        [Fact]
         public async void OpsTenantNoExpandNoFilterAndOrderBy()
         {
             Test(await Get<OpsTenant, TMandator>("/opstenant?$orderby=Name desc"));
@@ -631,33 +618,6 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
                     new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
-                );
-            }
-        }
-
-        private async Task<ICollection<TModel>> GetWithPageSize<TModel, TData>(string query, int pageSize, ODataQueryOptions<TModel> options = null) where TModel : class where TData : class
-        {
-            return
-            (
-                await DoGet
-                (
-                    serviceProvider.GetRequiredService<IMapper>(),
-                    serviceProvider.GetRequiredService<MyDbContext>()
-                )
-            ).ToList();
-
-            async Task<IQueryable<TModel>> DoGet(IMapper mapper, MyDbContext context)
-            {
-                return await context.Set<TData>().GetQueryAsync
-                (
-                    mapper,
-                    options ?? ODataHelpers.GetODataQueryOptions<TModel>
-                    (
-                        query,
-                        serviceProvider,
-                        serviceProvider.GetRequiredService<IRouteBuilder>()
-                    ),
-                    new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False, PageSize = pageSize}
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -590,7 +590,7 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
+                    new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
                 );
             }
         }
@@ -617,7 +617,7 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
+                    new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/GetTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetTests.cs
@@ -384,7 +384,7 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    new ODataQuerySettings{HandleNullPropagation = HandleNullPropagationOption.False}
+                    new QuerySettings{HandleNullPropagation = HandleNullPropagationOption.False}
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/GetTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetTests.cs
@@ -384,7 +384,7 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    HandleNullPropagationOption.False
+                    new ODataQuerySettings{HandleNullPropagation = HandleNullPropagationOption.False}
                 );
             }
         }


### PR DESCRIPTION
As discussed in issue #62 , this PRs intend was to allow the ODataQuerySettings to be passed in the methods IQueryable.Get/GetAsync/GetQuery.

However later we came to the conclusion that it would be better to use our own query settings type (QuerySettings) as not all options of ODataQuerySettings are supported currently. 

closes #62 