### PR TITLE
fixed issue: skip is ignored without top

### DIFF
--- a/AutoMapper.AspNetCore.OData.EFCore/Visitors/MethodAppender.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Visitors/MethodAppender.cs
@@ -30,7 +30,6 @@ namespace AutoMapper.AspNet.OData.Visitors
                 return node.GetQueryableMethod
                 (
                     expansion.QueryOptions.OrderByClause,
-                    elementType,
                     expansion.QueryOptions.Skip,
                     expansion.QueryOptions.Top
                 );

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -345,6 +345,36 @@ namespace AutoMapper.OData.EFCore.Tests
         }
 
         [Fact]
+        public async void BuildingExpandBuilderTenantExpandCitySkip2NoCount()
+        {
+            string query = "/corebuilding?$skip=2&$expand=Builder($expand=City),Tenant";
+            ODataQueryOptions<CoreBuilding> options = ODataHelpers.GetODataQueryOptions<CoreBuilding>
+            (
+                query,
+                serviceProvider,
+                serviceProvider.GetRequiredService<IRouteBuilder>()
+            );
+
+            Test
+            (
+                await Get<CoreBuilding, TBuilding>
+                (
+                    query,
+                    options
+                )
+            );
+
+            void Test(ICollection<CoreBuilding> collection)
+            {
+                Assert.Null(options.Request.ODataFeature().TotalCount);
+                Assert.Equal(3, collection.Count);
+                Assert.Equal("London", collection.First().Builder.City.Name);
+                Assert.Equal("Two L1", collection.First().Name);
+            }
+        }
+
+
+        [Fact]
         public async void BuildingSelectName_WithoutOrder_WithoutTop()
         {
             Test(await Get<CoreBuilding, TBuilding>("/corebuilding?$select=Name"));


### PR DESCRIPTION
While testing server side paging I found out that $skip will be ignored when there is not also a $top option. 

Updated LinqExtensions.QueryableMethods to support all cases (OrderBy / Skip / Top) and to return a value if any of these options are set.