### PR TITLE
Support parameterization in ProjectTo

### DIFF
--- a/AutoMapper.AspNet.OData.EF6/AutoMapper.AspNet.OData.EF6.csproj
+++ b/AutoMapper.AspNet.OData.EF6/AutoMapper.AspNet.OData.EF6.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\EdmTypeStructure.cs" Link="EdmTypeStructure.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\FilterHelper.cs" Link="FilterHelper.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\LinqExtensions.cs" Link="LinqExtensions.cs" />
+    <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\ProjectionSettings.cs" Link="ProjectionSettings.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Properties\Resources.Designer.cs" Link="Properties\Resources.Designer.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\QuerySettings.cs" Link="QuerySettings.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\TypeExtensions.cs" Link="TypeExtensions.cs" />

--- a/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
+++ b/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\FilterHelper.cs" Link="FilterHelper.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\LinqExtensions.cs" Link="LinqExtensions.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\ODataQueryOptionsExtensions.cs" Link="ODataQueryOptionsExtensions.cs" />
+    <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\ProjectionSettings.cs" Link="ProjectionSettings.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Properties\Resources.Designer.cs" Link="Properties\Resources.Designer.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\QuerySettings.cs" Link="QuerySettings.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\TypeExtensions.cs" Link="TypeExtensions.cs" />

--- a/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
@@ -82,30 +82,10 @@ namespace AutoMapper.AspNet.OData
         /// <param name="mapper"></param>
         /// <param name="options"></param>
         /// <param name="handleNullPropagation"></param>
-        /// <param name="parameters"></param>
         /// <returns></returns>
-        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default, object parameters = null)
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
             where TModel : class
-        {
-            var expansions = options.SelectExpand.GetExpansions(typeof(TModel));
-            List<Expression<Func<TModel, object>>> includeExpressions = expansions.Select(list => new List<Expansion>(list)).BuildIncludes<TModel>
-            (
-                options.SelectExpand.GetSelects()
-            )
-            .ToList();
-
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
-            Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
-            Expression<Func<IQueryable<TModel>, long>> countExpression = LinqExtensions.GetCountExpression<TModel>(filter);
-
-            options.AddExpandOptionsResult();
-            if (options.Count?.Value == true)
-                options.AddCountOptionsResult<TModel, TData>(await query.QueryAsync(mapper, countExpression));
-
-            IQueryable<TModel> queryable = await query.GetQueryAsync(mapper, filter, queryableExpression, includeExpressions, parameters);
-
-            return queryable.UpdateQueryableExpression(expansions);
-        }
+            => await query.GetQueryAsync(mapper, options, new QuerySettings { HandleNullPropagation = handleNullPropagation });
 
         /// <summary>
         /// GetQueryAsync
@@ -116,11 +96,29 @@ namespace AutoMapper.AspNet.OData
         /// <param name="mapper"></param>
         /// <param name="options"></param>
         /// <param name="querySettings"></param>
-        /// <param name="parameters"></param>
         /// <returns></returns>
-        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null, object parameters = null)
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
-            => await query.GetQueryAsync(mapper, options, querySettings == null ? HandleNullPropagationOption.Default : querySettings.HandleNullPropagation, parameters);
+        {
+            var expansions = options.SelectExpand.GetExpansions(typeof(TModel));
+            List<Expression<Func<TModel, object>>> includeExpressions = expansions.Select(list => new List<Expansion>(list)).BuildIncludes<TModel>
+            (
+                options.SelectExpand.GetSelects()
+            )
+            .ToList();
+
+            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings == null ? HandleNullPropagationOption.Default : querySettings.HandleNullPropagation);
+            Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
+            Expression<Func<IQueryable<TModel>, long>> countExpression = LinqExtensions.GetCountExpression<TModel>(filter);
+
+            options.AddExpandOptionsResult();
+            if (options.Count?.Value == true)
+                options.AddCountOptionsResult<TModel, TData>(await query.QueryAsync(mapper, countExpression));
+
+            IQueryable<TModel> queryable = await query.GetQueryAsync(mapper, filter, queryableExpression, includeExpressions, querySettings?.ProjectionSettings);
+
+            return queryable.UpdateQueryableExpression(expansions);
+        }
 
         /// <summary>
         /// Get
@@ -183,12 +181,13 @@ namespace AutoMapper.AspNet.OData
         /// <param name="filter"></param>
         /// <param name="queryFunc"></param>
         /// <param name="includeProperties"></param>
+        /// <param name="projectionSettings"></param>
         /// <returns></returns>
         public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper,
             Expression<Func<TModel, bool>> filter = null,
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryFunc = null,
             IEnumerable<Expression<Func<TModel, object>>> includeProperties = null,
-            object parameters = null)
+            ProjectionSettings projectionSettings = null)
         {
             //Map the expressions
             Expression<Func<TData, bool>> f = mapper.MapExpression<Expression<Func<TData, bool>>>(filter);
@@ -200,8 +199,8 @@ namespace AutoMapper.AspNet.OData
             return await Task.Run
             (
                 () => mappedQueryFunc != null
-                    ? mapper.ProjectTo(mappedQueryFunc(query), parameters, GetIncludes())
-                    : mapper.ProjectTo(query, parameters, GetIncludes())
+                    ? mapper.ProjectTo(mappedQueryFunc(query), projectionSettings?.Parameters, GetIncludes())
+                    : mapper.ProjectTo(query, projectionSettings?.Parameters, GetIncludes())
             );
 
             Expression<Func<TModel, object>>[] GetIncludes() => includeProperties?.ToArray() ?? new Expression<Func<TModel, object>>[] { };

--- a/AutoMapper.AspNetCore.OData.EFCore/ProjectionSettings.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/ProjectionSettings.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AutoMapper.AspNet.OData
+{
+    /// <summary>
+    /// Miscellaneous arguments for IMapper.ProjectTo
+    /// </summary>
+    public class ProjectionSettings
+    {
+        public object Parameters { get; set; }
+    }
+}

--- a/AutoMapper.AspNetCore.OData.EFCore/QuerySettings.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QuerySettings.cs
@@ -16,13 +16,10 @@ namespace AutoMapper.AspNet.OData
         /// </value>
         public HandleNullPropagationOption HandleNullPropagation { get; set; } = HandleNullPropagationOption.Default;
 
+        /// <summary>
+        /// Miscellaneous arguments for IMapper.ProjectTo
+        /// </summary>
+        public ProjectionSettings ProjectionSettings { get; set; }
 
-        internal ODataQuerySettings AsODataQuerySettings()
-        {
-            return new ODataQuerySettings
-            {
-                HandleNullPropagation = HandleNullPropagation
-            };
-        }
     }
 }

--- a/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
@@ -41,7 +41,7 @@ namespace AutoMapper.AspNet.OData
             where TModel : class
             => await query.GetAsync(mapper, options, querySettings == null ? HandleNullPropagationOption.Default : querySettings.HandleNullPropagation);
 
-        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default, object parameters = null)
             where TModel : class
         {
             var expansions = options.SelectExpand.GetExpansions(typeof(TModel));
@@ -59,14 +59,14 @@ namespace AutoMapper.AspNet.OData
             if (options.Count?.Value == true)
                 options.AddCountOptionsResult<TModel, TData>(await query.QueryAsync(mapper, countExpression));
 
-            IQueryable<TModel> queryable = await query.GetQueryAsync(mapper, filter, queryableExpression, includeExpressions);
+            IQueryable<TModel> queryable = await query.GetQueryAsync(mapper, filter, queryableExpression, includeExpressions, parameters);
 
             return queryable.UpdateQueryableExpression(expansions);
         }
 
-        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null, object parameters = null)
             where TModel : class
-            => await query.GetQueryAsync(mapper, options, querySettings == null ? HandleNullPropagationOption.Default : querySettings.HandleNullPropagation);
+            => await query.GetQueryAsync(mapper, options, querySettings == null ? HandleNullPropagationOption.Default : querySettings.HandleNullPropagation, parameters);
 
         public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper,
             Expression<Func<TModel, bool>> filter = null,
@@ -101,7 +101,8 @@ namespace AutoMapper.AspNet.OData
         public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper,
             Expression<Func<TModel, bool>> filter = null,
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryFunc = null,
-            IEnumerable<Expression<Func<TModel, object>>> includeProperties = null)
+            IEnumerable<Expression<Func<TModel, object>>> includeProperties = null,
+            object parameters = null)
         {
             //Map the expressions
             Expression<Func<TData, bool>> f = mapper.MapExpression<Expression<Func<TData, bool>>>(filter);
@@ -113,8 +114,8 @@ namespace AutoMapper.AspNet.OData
             return await Task.Run
             (
                 () => mappedQueryFunc != null
-                    ? mapper.ProjectTo(mappedQueryFunc(query), null, GetIncludes())
-                    : mapper.ProjectTo(query, null, GetIncludes())
+                    ? mapper.ProjectTo(mappedQueryFunc(query), parameters, GetIncludes())
+                    : mapper.ProjectTo(query, parameters, GetIncludes())
             );
 
             Expression<Func<TModel, object>>[] GetIncludes() => includeProperties?.ToArray() ?? new Expression<Func<TModel, object>>[] { };

--- a/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
@@ -41,7 +41,11 @@ namespace AutoMapper.AspNet.OData
             where TModel : class
             => await query.GetAsync(mapper, options, querySettings == null ? HandleNullPropagationOption.Default : querySettings.HandleNullPropagation);
 
-        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default, object parameters = null)
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default)
+            where TModel : class
+            => await query.GetQueryAsync(mapper, options, new QuerySettings { HandleNullPropagation = handleNullPropagation });
+
+        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
             var expansions = options.SelectExpand.GetExpansions(typeof(TModel));
@@ -51,7 +55,7 @@ namespace AutoMapper.AspNet.OData
             )
             .ToList();
 
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(handleNullPropagation);
+            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings == null ? HandleNullPropagationOption.False : querySettings.HandleNullPropagation);
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryableExpression = options.GetQueryableExpression();
             Expression<Func<IQueryable<TModel>, long>> countExpression = LinqExtensions.GetCountExpression<TModel>(filter);
 
@@ -59,14 +63,10 @@ namespace AutoMapper.AspNet.OData
             if (options.Count?.Value == true)
                 options.AddCountOptionsResult<TModel, TData>(await query.QueryAsync(mapper, countExpression));
 
-            IQueryable<TModel> queryable = await query.GetQueryAsync(mapper, filter, queryableExpression, includeExpressions, parameters);
+            IQueryable<TModel> queryable = await query.GetQueryAsync(mapper, filter, queryableExpression, includeExpressions, querySettings?.ProjectionSettings);
 
             return queryable.UpdateQueryableExpression(expansions);
         }
-
-        public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null, object parameters = null)
-            where TModel : class
-            => await query.GetQueryAsync(mapper, options, querySettings == null ? HandleNullPropagationOption.Default : querySettings.HandleNullPropagation, parameters);
 
         public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper,
             Expression<Func<TModel, bool>> filter = null,
@@ -102,7 +102,7 @@ namespace AutoMapper.AspNet.OData
             Expression<Func<TModel, bool>> filter = null,
             Expression<Func<IQueryable<TModel>, IQueryable<TModel>>> queryFunc = null,
             IEnumerable<Expression<Func<TModel, object>>> includeProperties = null,
-            object parameters = null)
+            ProjectionSettings projectionSettings = null)
         {
             //Map the expressions
             Expression<Func<TData, bool>> f = mapper.MapExpression<Expression<Func<TData, bool>>>(filter);
@@ -114,8 +114,8 @@ namespace AutoMapper.AspNet.OData
             return await Task.Run
             (
                 () => mappedQueryFunc != null
-                    ? mapper.ProjectTo(mappedQueryFunc(query), parameters, GetIncludes())
-                    : mapper.ProjectTo(query, parameters, GetIncludes())
+                    ? mapper.ProjectTo(mappedQueryFunc(query), projectionSettings?.Parameters, GetIncludes())
+                    : mapper.ProjectTo(query, projectionSettings?.Parameters, GetIncludes())
             );
 
             Expression<Func<TModel, object>>[] GetIncludes() => includeProperties?.ToArray() ?? new Expression<Func<TModel, object>>[] { };

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -169,6 +169,29 @@ namespace AutoMapper.OData.EFCore.Tests
         }
 
         [Fact]
+        public async void BuildingExpandBuilderTenantFilterEqAndOrderByWithParameter()
+        {
+            string buildingParameterValue = Guid.NewGuid().ToString();
+            int builderParameterValue = new Random().Next();
+            var parameters = new
+            {
+                buildingParameter = buildingParameterValue,
+                builderParameter = builderParameterValue
+            };
+
+            Test(await Get<CoreBuilding, TBuilding>("/corebuilding?$top=1&$expand=Builder&$filter=name eq 'One L1'", null, parameters));
+
+            void Test(ICollection<CoreBuilding> collection)
+            {
+                Assert.Equal(1, collection.Count);
+                Assert.Equal("One L1", collection.First().Name);
+                Assert.Equal(buildingParameterValue, collection.First().Parameter);
+                Assert.Equal("Sam", collection.First().Builder.Name);
+                Assert.Equal(builderParameterValue, collection.First().Builder.Parameter);
+            }
+        }
+
+        [Fact]
         public async void BuildingExpandBuilderTenantFilterEqAndOrderBy()
         {
             Test(await Get<CoreBuilding, TBuilding>("/corebuilding?$top=5&$expand=Builder,Tenant&$filter=name eq 'One L1'"));
@@ -589,7 +612,7 @@ namespace AutoMapper.OData.EFCore.Tests
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, IQueryable<TData> dataQueryable, ODataQueryOptions<TModel> options = null) where TModel : class where TData : class
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, IQueryable<TData> dataQueryable, ODataQueryOptions<TModel> options = null, object parameters = null) where TModel : class where TData : class
         {
             return
             (
@@ -610,12 +633,13 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
+                    new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.False },
+                    parameters
                 );
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null) where TModel : class where TData : class
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null, object parameters = null) where TModel : class where TData : class
         {
             return 
             (
@@ -637,7 +661,8 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }
+                    new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.False },
+                    parameters
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -179,7 +179,19 @@ namespace AutoMapper.OData.EFCore.Tests
                 builderParameter = builderParameterValue
             };
 
-            Test(await Get<CoreBuilding, TBuilding>("/corebuilding?$top=1&$expand=Builder&$filter=name eq 'One L1'", null, parameters));
+            Test
+            (
+                await Get<CoreBuilding, TBuilding>
+                (
+                    "/corebuilding?$top=1&$expand=Builder&$filter=name eq 'One L1'", 
+                    null, 
+                    new QuerySettings
+                    {
+                        ProjectionSettings = new ProjectionSettings { Parameters = parameters },
+                        HandleNullPropagation = HandleNullPropagationOption.False
+                    }
+                )
+            );
 
             void Test(ICollection<CoreBuilding> collection)
             {
@@ -612,7 +624,7 @@ namespace AutoMapper.OData.EFCore.Tests
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, IQueryable<TData> dataQueryable, ODataQueryOptions<TModel> options = null, object parameters = null) where TModel : class where TData : class
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, IQueryable<TData> dataQueryable, ODataQueryOptions<TModel> options = null, QuerySettings querySettings = null) where TModel : class where TData : class
         {
             return
             (
@@ -633,13 +645,12 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.False },
-                    parameters
+                    querySettings
                 );
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null, object parameters = null) where TModel : class where TData : class
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null, QuerySettings querySettings = null) where TModel : class where TData : class
         {
             return 
             (
@@ -661,8 +672,7 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.False },
-                    parameters
+                    querySettings
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/Mappings/CoreBuildingMappings.cs
+++ b/AutoMapper.OData.EFCore.Tests/Mappings/CoreBuildingMappings.cs
@@ -7,12 +7,18 @@ namespace AutoMapper.OData.EFCore.Tests.Mappings
     {
         public CoreBuildingMappings()
         {
+            // Dummy variables for automapper to pull the names for parameters
+            string buildingParameter = null;
+            int builderParameter = 0;
+
             CreateMap<TBuilding, CoreBuilding>()
                 .ForMember(d => d.Name, o => o.MapFrom(s => s.LongName))
                 .ForMember(d => d.Tenant, o => o.MapFrom(s => s.Mandator))
+                .ForMember(d => d.Parameter, o => o.MapFrom(s => buildingParameter))
                 .ForAllMembers(o => o.ExplicitExpansion());
 
             CreateMap<TBuilder, OpsBuilder>()
+                .ForMember(d => d.Parameter, o => o.MapFrom(s => builderParameter))
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<TCity, OpsCity>()
                 .ForAllMembers(o => o.ExplicitExpansion());

--- a/Domain.OData/CoreBuilding.cs
+++ b/Domain.OData/CoreBuilding.cs
@@ -10,5 +10,6 @@ namespace Domain.OData
         public string Name { get; set; }
         public OpsBuilder Builder { get; set; }
         public OpsTenant Tenant { get; set; }
+        public string Parameter { get; set; }
     }
 }

--- a/Domain.OData/OpsBuilder.cs
+++ b/Domain.OData/OpsBuilder.cs
@@ -9,5 +9,6 @@ namespace Domain.OData
         public Int32 Id { get; set; }
         public String Name { get; set; }
         public OpsCity City { get; set; }
+        public Int32 Parameter { get; set; }
     }
 }

--- a/WebAPI.AspNet.OData.EF6/Controllers/OpsTenantController.cs
+++ b/WebAPI.AspNet.OData.EF6/Controllers/OpsTenantController.cs
@@ -28,7 +28,7 @@ namespace WebAPI.AspNet.OData.EF6.Controllers
         [HttpGet]
         public async Task<IHttpActionResult> Get(ODataQueryOptions<CoreBuilding> options)
         {
-            return Ok(await Repository.BuildingSet.GetQueryAsync(this._mapper, options, HandleNullPropagationOption.Default));
+            return Ok(await Repository.BuildingSet.GetQueryAsync(this._mapper, options, new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.Default }));
         }
     }
 
@@ -47,7 +47,7 @@ namespace WebAPI.AspNet.OData.EF6.Controllers
         [HttpGet]
         public async Task<IHttpActionResult> Get(ODataQueryOptions<OpsTenant> options)
         {
-            return Ok(await Repository.MandatorSet.GetQueryAsync(this._mapper, options, HandleNullPropagationOption.Default));
+            return Ok(await Repository.MandatorSet.GetQueryAsync(this._mapper, options, new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.Default }));
         }
     }
 }

--- a/WebAPI.OData.EFCore/Controllers/OpsTenantController.cs
+++ b/WebAPI.OData.EFCore/Controllers/OpsTenantController.cs
@@ -25,7 +25,7 @@ namespace WebAPI.OData.EFCore.Controllers
         [HttpGet]
         public async Task<IActionResult> Get(ODataQueryOptions<OpsTenant> options)
         {
-            return Ok(await Repository.MandatorSet.GetQueryAsync(_mapper, options, HandleNullPropagationOption.False));
+            return Ok(await Repository.MandatorSet.GetQueryAsync(_mapper, options, new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }));
         }
     }
 
@@ -43,7 +43,7 @@ namespace WebAPI.OData.EFCore.Controllers
         [HttpGet]
         public async Task<IActionResult> Get(ODataQueryOptions<CoreBuilding> options)
         {
-            return Ok(await Repository.BuildingSet.GetQueryAsync(_mapper, options, HandleNullPropagationOption.False));
+            return Ok(await Repository.BuildingSet.GetQueryAsync(_mapper, options, new QuerySettings { HandleNullPropagation = HandleNullPropagationOption.False }));
         }
     }
 }


### PR DESCRIPTION
ProjectTo supports parameters to be evaluated at runtime

https://docs.automapper.org/en/stable/Queryable-Extensions.html#parameterization

We have utilized the generic object signature for ProjectTo
https://github.com/AutoMapper/AutoMapper/blob/565c9634e2a0b487c9b25bca20f67a43e0ee06a3/src/AutoMapper/QueryableExtensions/Extensions.cs#L36