### PR TITLE
Cancellation support added

### DIFF
--- a/AutoMapper.OData.EF6.Tests/GetQuerySelectTests.cs
+++ b/AutoMapper.OData.EF6.Tests/GetQuerySelectTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -115,7 +116,17 @@ namespace AutoMapper.OData.EF6.Tests
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null) where TModel : class where TData : class
+        #region Negative
+        [Fact]
+        public async Task CancellationThrowsException()
+        {
+            var cancelledToken = new CancellationTokenSource(TimeSpan.Zero).Token;
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Get<CoreBuilding, TBuilding>("/corebuilding", cancellationToken: cancelledToken));
+        }
+        #endregion Negative
+
+
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null, CancellationToken cancellationToken = default) where TModel : class where TData : class
         {
             return
             (
@@ -137,7 +148,8 @@ namespace AutoMapper.OData.EF6.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    new QuerySettings { ODataSettings = new ODataSettings { HandleNullPropagation = HandleNullPropagationOption.False } }
+                    new QuerySettings { ODataSettings = new ODataSettings { HandleNullPropagation = HandleNullPropagationOption.False } },
+                    cancellationToken
                 );
             }
         }

--- a/AutoMapper.OData.EF6.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EF6.Tests/GetQueryTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -737,7 +738,16 @@ namespace AutoMapper.OData.EF6.Tests
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, IQueryable<TData> dataQueryable, ODataQueryOptions<TModel> options = null, QuerySettings querySettings = null) where TModel : class where TData : class
+        #region Negative
+        [Fact]
+        public async Task CancellationThrowsException()
+        {
+            var cancelledToken = new CancellationTokenSource(TimeSpan.Zero).Token;
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Get<CategoryModel, Category>("/CategoryModel", GetCategories(), cancellationToken: cancelledToken));
+        }
+        #endregion Negative
+
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, IQueryable<TData> dataQueryable, ODataQueryOptions<TModel> options = null, QuerySettings querySettings = null, CancellationToken cancellationToken = default) where TModel : class where TData : class
         {
             return
             (
@@ -758,7 +768,8 @@ namespace AutoMapper.OData.EF6.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    querySettings
+                    querySettings,
+                    cancellationToken
                 );
             }
         }

--- a/AutoMapper.OData.EF6.Tests/GetTests.cs
+++ b/AutoMapper.OData.EF6.Tests/GetTests.cs
@@ -15,6 +15,7 @@ using Microsoft.OData.Edm;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -455,7 +456,16 @@ namespace AutoMapper.OData.EF6.Tests
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null, int? pageSize = null) where TModel : class where TData : class
+        #region Negative
+        [Fact]
+        public async Task CancellationThrowsException()
+        {
+            var cancelledToken = new CancellationTokenSource(TimeSpan.Zero).Token;
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Get<CoreBuilding, TBuilding>("/corebuilding", cancellationToken: cancelledToken));
+        }
+        #endregion Negative
+
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null, int? pageSize = null, CancellationToken cancellationToken = default) where TModel : class where TData : class
         {
             return await DoGet
             (
@@ -481,7 +491,8 @@ namespace AutoMapper.OData.EF6.Tests
                             HandleNullPropagation = HandleNullPropagationOption.False,
                             PageSize = pageSize
                         } 
-                    }
+                    },
+                    cancellationToken
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/GetQuerySelectTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQuerySelectTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -128,7 +129,16 @@ namespace AutoMapper.OData.EFCore.Tests
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null) where TModel : class where TData : class
+        #region Negative
+        [Fact]
+        public async Task CancellationThrowsException()
+        {
+            var cancelledToken = new CancellationTokenSource(TimeSpan.Zero).Token;
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Get<CoreBuilding, TBuilding>("/corebuilding", cancellationToken: cancelledToken));
+        }
+        #endregion Negative
+
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null, CancellationToken cancellationToken = default) where TModel : class where TData : class
         {
             return
             (
@@ -150,7 +160,8 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    new QuerySettings { ODataSettings = new ODataSettings { HandleNullPropagation = HandleNullPropagationOption.False } }
+                    new QuerySettings { ODataSettings = new ODataSettings { HandleNullPropagation = HandleNullPropagationOption.False } },
+                    cancellationToken
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -750,7 +751,16 @@ namespace AutoMapper.OData.EFCore.Tests
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, IQueryable<TData> dataQueryable, ODataQueryOptions<TModel> options = null, QuerySettings querySettings = null) where TModel : class where TData : class
+        #region Negative
+        [Fact]
+        public async Task CancellationThrowsException()
+        {
+            var cancelledToken = new CancellationTokenSource(TimeSpan.Zero).Token;
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Get<CategoryModel, Category>("/CategoryModel", GetCategories(), cancellationToken: cancelledToken));
+        }
+        #endregion Negative
+
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, IQueryable<TData> dataQueryable, ODataQueryOptions<TModel> options = null, QuerySettings querySettings = null, CancellationToken cancellationToken = default) where TModel : class where TData : class
         {
             return
             (
@@ -771,7 +781,8 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    querySettings
+                    querySettings,
+                    cancellationToken
                 );
             }
         }

--- a/AutoMapper.OData.EFCore.Tests/GetTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetTests.cs
@@ -16,6 +16,7 @@ using Microsoft.OData.Edm;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -468,7 +469,16 @@ namespace AutoMapper.OData.EFCore.Tests
             }
         }
 
-        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null, int? pageSize = null) where TModel : class where TData : class
+        #region Negative
+        [Fact]
+        public async Task CancellationThrowsException()
+        {
+            var cancelledToken = new CancellationTokenSource(TimeSpan.Zero).Token;
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Get<CoreBuilding, TBuilding>("/corebuilding", cancellationToken: cancelledToken));
+        }
+        #endregion Negative
+
+        private async Task<ICollection<TModel>> Get<TModel, TData>(string query, ODataQueryOptions<TModel> options = null, int? pageSize = null, CancellationToken cancellationToken = default) where TModel : class where TData : class
         {
             return await DoGet
             (
@@ -487,7 +497,8 @@ namespace AutoMapper.OData.EFCore.Tests
                         serviceProvider,
                         serviceProvider.GetRequiredService<IRouteBuilder>()
                     ),
-                    new QuerySettings{ ODataSettings = new ODataSettings { HandleNullPropagation = HandleNullPropagationOption.False, PageSize = pageSize } }
+                    new QuerySettings{ ODataSettings = new ODataSettings { HandleNullPropagation = HandleNullPropagationOption.False, PageSize = pageSize } },
+                    cancellationToken
                 );
             }
         }


### PR DESCRIPTION
Async methods in `QueryableExtensions` are extended with the `CancellationToken` parameter to add cancellation support.

There are three main changes:
1. `CancellationToken` param added where needed. Impacts all asynchronous methods.
2. `Task.Result` changed to `Task.GetAwaiter().GetResult()` to avoid `AggregateException` wrapping. Impacts synchronous methods only.
3. `EF6.QueryableExtensions.GetAsync<TModel, TData>` method logic is modified to use `ToListAsync` instead of `ToList`

In addition, you'll notice some formatting changes, mainly in method signatures. I have used 200 chars line width as a guideline. After which, I started to break the signature into multiple lines. If you still prefer a single line signature, I can easily revert.
