### PR TITLE
Add support for $search

### DIFF
--- a/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
+++ b/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
@@ -68,7 +68,7 @@
     <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[5.0.0,6.0.0)" />
     <PackageReference Include="EntityFramework" Version="6.3.0" />
     <PackageReference Include="LogicBuilder.Expressions.Utils" Version="[5.0.0,6.0.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.6" />
     <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
+++ b/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
@@ -57,6 +57,7 @@
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Visitors\FilterAppender.cs" Link="Visitors\FilterAppender.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Visitors\MethodAppender.cs" Link="Visitors\MethodAppender.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Visitors\ProjectionVisitor.cs" Link="Visitors\ProjectionVisitor.cs" />
+    <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Visitors\ParameterReplacer.cs" Link="Visitors\ParameterReplacer.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -67,7 +68,7 @@
     <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[5.0.0,6.0.0)" />
     <PackageReference Include="EntityFramework" Version="6.3.0" />
     <PackageReference Include="LogicBuilder.Expressions.Utils" Version="[5.0.0,6.0.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.7" />
     <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
@@ -31,7 +31,7 @@ namespace AutoMapper.AspNet.OData
         public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.Default);
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.Default);
             query.ApplyOptions(mapper, filter, options, querySettings);
             return query.Get
             (
@@ -55,7 +55,7 @@ namespace AutoMapper.AspNet.OData
         public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.Default);
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.Default);
             await query.ApplyOptionsAsync(mapper, filter, options, querySettings);
             return await query.GetAsync
             (
@@ -80,7 +80,7 @@ namespace AutoMapper.AspNet.OData
         public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False);
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False);
             await query.ApplyOptionsAsync(mapper, filter, options, querySettings);
             return query.GetQueryable(mapper, options, querySettings, filter);
         }
@@ -98,7 +98,7 @@ namespace AutoMapper.AspNet.OData
         public static IQueryable<TModel> GetQuery<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False);
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False);
             query.ApplyOptions(mapper, filter, options, querySettings);
             return query.GetQueryable(mapper, options, querySettings, filter);
         }

--- a/AutoMapper.AspNetCore.OData.EFCore/AutoMapper.AspNetCore.OData.EFCore.csproj
+++ b/AutoMapper.AspNetCore.OData.EFCore/AutoMapper.AspNetCore.OData.EFCore.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[5.0.0,6.0.0)" />
     <PackageReference Include="LogicBuilder.Expressions.Utils" Version="[5.0.0,6.0.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>

--- a/AutoMapper.AspNetCore.OData.EFCore/AutoMapper.AspNetCore.OData.EFCore.csproj
+++ b/AutoMapper.AspNetCore.OData.EFCore/AutoMapper.AspNetCore.OData.EFCore.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[5.0.0,6.0.0)" />
     <PackageReference Include="LogicBuilder.Expressions.Utils" Version="[5.0.0,6.0.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>

--- a/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
@@ -17,9 +17,10 @@ namespace AutoMapper.AspNet.OData
         public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(
                 querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
                 querySettings?.ODataSettings?.TimeZone);
+
             query.ApplyOptions(mapper, filter, options, querySettings);
             return query.Get
             (
@@ -33,7 +34,7 @@ namespace AutoMapper.AspNet.OData
         public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(
                 querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
                 querySettings?.ODataSettings?.TimeZone);
             await query.ApplyOptionsAsync(mapper, filter, options, querySettings);
@@ -50,9 +51,10 @@ namespace AutoMapper.AspNet.OData
         public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(
-                querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
-                querySettings?.ODataSettings?.TimeZone);
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(
+                     querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
+                     querySettings?.ODataSettings?.TimeZone);
+                
             await query.ApplyOptionsAsync(mapper, filter, options, querySettings);
             return query.GetQueryable(mapper, options, querySettings, filter);
         }
@@ -60,7 +62,7 @@ namespace AutoMapper.AspNet.OData
         public static IQueryable<TModel> GetQuery<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.Filter.ToFilterExpression<TModel>(
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(
                 querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
                 querySettings?.ODataSettings?.TimeZone);
             query.ApplyOptions(mapper, filter, options, querySettings);

--- a/AutoMapper.AspNetCore.OData.EFCore/Visitors/ParameterReplacer.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Visitors/ParameterReplacer.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq.Expressions;
+
+namespace AutoMapper.AspNet.OData.Visitors
+{
+    internal class ParameterReplacer : ExpressionVisitor
+    {
+        private readonly ParameterExpression _source;
+        private readonly Expression _target;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="source"><see cref="ParameterExpression"/>.</param>
+        /// <param name="target"><see cref="Expression"/>.</param>
+        public ParameterReplacer(ParameterExpression source, Expression target)
+        {
+            _source = source;
+            _target = target;
+        }
+
+        /// <inheritdoc cref="VisitParameter(ParameterExpression)"/>
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            return node == _source ? _target : base.VisitParameter(node);
+        }
+    }    
+}

--- a/AutoMapper.OData.EF6.Tests/Binders/OpsTenantSearchBinder.cs
+++ b/AutoMapper.OData.EF6.Tests/Binders/OpsTenantSearchBinder.cs
@@ -4,14 +4,15 @@ using Domain.OData;
 using Microsoft.AspNetCore.OData.Query.Expressions;
 using Microsoft.OData.UriParser;
 
-namespace AutoMapper.OData.EF6.Tests.Binders;
-
-public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
+namespace AutoMapper.OData.EF6.Tests.Binders
 {
-    public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+    public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
     {
-        SearchTermNode node = searchClause.Expression as SearchTermNode;
-        Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
-        return exp;
+        public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+        {
+            SearchTermNode node = searchClause.Expression as SearchTermNode;
+            Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
+            return exp;
+        }
     }
 }

--- a/AutoMapper.OData.EF6.Tests/Binders/OpsTenantSearchBinder.cs
+++ b/AutoMapper.OData.EF6.Tests/Binders/OpsTenantSearchBinder.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq.Expressions;
+using Domain.OData;
+using Microsoft.AspNetCore.OData.Query.Expressions;
+using Microsoft.OData.UriParser;
+
+namespace AutoMapper.OData.EF6.Tests.Binders;
+
+public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
+{
+    public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+    {
+        SearchTermNode node = searchClause.Expression as SearchTermNode;
+        Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
+        return exp;
+    }
+}

--- a/AutoMapper.OData.EF6.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EF6.Tests/GetQueryTests.cs
@@ -54,6 +54,31 @@ namespace AutoMapper.OData.EF6.Tests
         }
 
         [Fact]
+        public async void OpsTenantSearch()
+        {
+            Test(Get<OpsTenant, TMandator>("/opstenant?$search=One"));
+            Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$search=One"));
+
+            void Test(ICollection<OpsTenant> collection)
+            {
+                Assert.Equal(1, collection.Count);
+                Assert.Equal("One", collection.First().Name);
+            }
+        }
+        
+        [Fact]
+        public async void OpsTenantSearchAndFilter()
+        {
+            Test(Get<OpsTenant, TMandator>("/opstenant?$search=One&$filter=Name eq 'Two'"));
+            Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$search=One&$filter=Name eq 'Two'"));
+
+            void Test(ICollection<OpsTenant> collection)
+            {
+                Assert.Equal(0, collection.Count);
+            }
+        }
+        
+        [Fact]
         public async void OpsTenantExpandBuildingsFilterEqAndOrderBy()
         {
             Test(Get<OpsTenant, TMandator>("/opstenant?$top=5&$expand=Buildings&$filter=Name eq 'One'&$orderby=Name desc"));

--- a/AutoMapper.OData.EF6.Tests/GetTests.cs
+++ b/AutoMapper.OData.EF6.Tests/GetTests.cs
@@ -17,6 +17,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using AutoMapper.OData.EF6.Tests.Binders;
+using Microsoft.AspNetCore.OData.Query.Expressions;
 using Xunit;
 
 namespace AutoMapper.OData.EF6.Tests
@@ -537,18 +539,22 @@ namespace AutoMapper.OData.EF6.Tests
             IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet(typeof(T).Name);
             ODataPath path = new ODataPath(new Microsoft.OData.UriParser.EntitySetSegment(entitySet));
 
-            return new ODataQueryOptions<T>
+            var request = new DefaultHttpContext()
+            {
+                RequestServices = serviceProvider
+            }.Request;
+            
+            var oDataOptions = new ODataOptions().AddRouteComponents("key", model,
+                x => x.AddSingleton<ISearchBinder, OpsTenantSearchBinder>());
+            var (_, routeProvider) = oDataOptions.RouteComponents["key"];
+            
+            request.ODataFeature().Services = routeProvider;
+            var oDataQueryOptions = new ODataQueryOptions<T>
             (
                 new ODataQueryContext(model, typeof(T), path),
-                BuildRequest
-                (
-                    new DefaultHttpContext()
-                    {
-                        RequestServices = serviceProvider
-                    }.Request,
-                    new Uri(BASEADDRESS + queryString)
-                )
+                BuildRequest(request, new Uri(BASEADDRESS + queryString))
             );
+            return oDataQueryOptions;
 
             static HttpRequest BuildRequest(HttpRequest request, Uri uri)
             {

--- a/AutoMapper.OData.EFCore.Tests/Binders/OpsTenantSearchBinder.cs
+++ b/AutoMapper.OData.EFCore.Tests/Binders/OpsTenantSearchBinder.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq.Expressions;
+using Domain.OData;
+using Microsoft.AspNetCore.OData.Query.Expressions;
+using Microsoft.OData.UriParser;
+
+namespace AutoMapper.OData.EFCore.Tests.Binders;
+
+public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
+{
+    public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+    {
+        SearchTermNode node = searchClause.Expression as SearchTermNode;
+        Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
+        return exp;
+    }
+}

--- a/AutoMapper.OData.EFCore.Tests/Binders/OpsTenantSearchBinder.cs
+++ b/AutoMapper.OData.EFCore.Tests/Binders/OpsTenantSearchBinder.cs
@@ -4,14 +4,15 @@ using Domain.OData;
 using Microsoft.AspNetCore.OData.Query.Expressions;
 using Microsoft.OData.UriParser;
 
-namespace AutoMapper.OData.EFCore.Tests.Binders;
-
-public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
+namespace AutoMapper.OData.EFCore.Tests.Binders
 {
-    public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+    public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
     {
-        SearchTermNode node = searchClause.Expression as SearchTermNode;
-        Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
-        return exp;
+        public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+        {
+            SearchTermNode node = searchClause.Expression as SearchTermNode;
+            Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
+            return exp;
+        }
     }
 }

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -1,4 +1,9 @@
-﻿using AutoMapper.AspNet.OData;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper.AspNet.OData;
 using AutoMapper.OData.EFCore.Tests.Data;
 using AutoMapper.OData.EFCore.Tests.Model;
 using DAL.EFCore;
@@ -9,11 +14,6 @@ using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace AutoMapper.OData.EFCore.Tests
@@ -52,7 +52,7 @@ namespace AutoMapper.OData.EFCore.Tests
                 .AddTransient<IApplicationBuilder>(sp => new ApplicationBuilder(sp))
                 .AddRouting()
                 .AddLogging();
-
+            
             serviceProvider = services.BuildServiceProvider();
 
             MyDbContext context = serviceProvider.GetRequiredService<MyDbContext>();
@@ -64,6 +64,31 @@ namespace AutoMapper.OData.EFCore.Tests
         public void IsConfigurationValid()
         {
             serviceProvider.GetRequiredService<IConfigurationProvider>().AssertConfigurationIsValid();
+        }
+        
+        [Fact]
+        public async void OpsTenantSearch()
+        {
+            Test(Get<OpsTenant, TMandator>("/opstenant?$search=One"));
+            Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$search=One"));
+
+            void Test(ICollection<OpsTenant> collection)
+            {
+                Assert.Equal(1, collection.Count);
+                Assert.Equal("One", collection.First().Name);
+            }
+        }
+        
+        [Fact]
+        public async void OpsTenantSearchAndFilter()
+        {
+            Test(Get<OpsTenant, TMandator>("/opstenant?$search=One&$filter=Name eq 'Two'"));
+            Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$search=One&$filter=Name eq 'Two'"));
+
+            void Test(ICollection<OpsTenant> collection)
+            {
+                Assert.Equal(0, collection.Count);
+            }
         }
 
         [Fact]

--- a/Web.Tests/GetTests.cs
+++ b/Web.Tests/GetTests.cs
@@ -30,6 +30,64 @@ namespace Web.Tests
 
             this.clientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
         }
+        
+        [Theory]
+        [InlineData("16324")]
+        [InlineData("16325")]
+        public async void OpsTenantSearchAndFilterNoResult(string port)
+        {
+            Test(await Get<OpsTenant>("/opstenant?$search=One&$filter=Name eq 'Two'", port));
+
+            void Test(ICollection<OpsTenant> collection)
+            {
+                Assert.Equal(0, collection.Count);
+            }
+        }
+        
+        [Theory]
+        [InlineData("16324")]
+        [InlineData("16325")]
+        public async void OpsTenantSearchAndFilterExpand(string port)
+        {
+            Test(await Get<OpsTenant>("/opstenant?$search=One&$filter=CreatedDate gt 2012-11-11T00:00:00.00Z&$expand=Buildings", port));
+
+            void Test(ICollection<OpsTenant> collection)
+            {
+                Assert.Equal(1, collection.Count);
+                Assert.Equal(2, collection.First().Buildings.Count);
+                Assert.Equal("One", collection.First().Name);
+            }
+        }
+        
+        [Theory]
+        [InlineData("16324")]
+        [InlineData("16325")]
+        public async void OpsTenantSearchExpand(string port)
+        {
+            Test(await Get<OpsTenant>("/opstenant?$search=One&$expand=Buildings", port));
+
+            void Test(ICollection<OpsTenant> collection)
+            {
+                Assert.Equal(1, collection.Count);
+                Assert.Equal(2, collection.First().Buildings.Count);
+                Assert.Equal("One", collection.First().Name);
+            }
+        }
+
+        [Theory]
+        [InlineData("16324")]
+        [InlineData("16325")]
+        public async void OpsTenantSearchNoExpand(string port)
+        {
+            Test(await Get<OpsTenant>("/opstenant?$search=One", port));
+
+            void Test(ICollection<OpsTenant> collection)
+            {
+                Assert.Equal(1, collection.Count);
+                Assert.False(collection.First()?.Buildings?.Any() == true);
+                Assert.Equal("One", collection.First().Name);
+            }
+        }
 
         [Theory]
         [InlineData("16324")]

--- a/WebAPI.OData.EF6/Binders/OpsTenantSearchBinder.cs
+++ b/WebAPI.OData.EF6/Binders/OpsTenantSearchBinder.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq.Expressions;
+using Domain.OData;
+using Microsoft.AspNetCore.OData.Query.Expressions;
+using Microsoft.OData.UriParser;
+
+namespace WebAPI.OData.EF6.Binders;
+
+public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
+{
+    public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+    {
+        SearchTermNode node = searchClause.Expression as SearchTermNode;
+        Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
+        return exp;
+    }
+}

--- a/WebAPI.OData.EF6/Binders/OpsTenantSearchBinder.cs
+++ b/WebAPI.OData.EF6/Binders/OpsTenantSearchBinder.cs
@@ -4,14 +4,15 @@ using Domain.OData;
 using Microsoft.AspNetCore.OData.Query.Expressions;
 using Microsoft.OData.UriParser;
 
-namespace WebAPI.OData.EF6.Binders;
-
-public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
+namespace WebAPI.OData.EF6.Binders
 {
-    public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+    public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
     {
-        SearchTermNode node = searchClause.Expression as SearchTermNode;
-        Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
-        return exp;
+        public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+        {
+            SearchTermNode node = searchClause.Expression as SearchTermNode;
+            Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
+            return exp;
+        }
     }
 }

--- a/WebAPI.OData.EF6/Properties/launchSettings.json
+++ b/WebAPI.OData.EF6/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "api/values",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "http://localhost:16325",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/WebAPI.OData.EF6/Startup.cs
+++ b/WebAPI.OData.EF6/Startup.cs
@@ -4,11 +4,13 @@ using Domain.OData;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Query.Expressions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
+using WebAPI.OData.EF6.Binders;
 
 namespace WebAPI.OData.EF6
 {
@@ -24,7 +26,9 @@ namespace WebAPI.OData.EF6
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers().AddOData(opt => opt.AddRouteComponents("", GetEdmModel()).Count().Filter().OrderBy().Expand().Select().SetMaxTop(null));
+            services.AddControllers()
+                .AddOData(opt => opt.EnableQueryFeatures()
+                    .AddRouteComponents("", GetEdmModel(), services => services.AddSingleton<ISearchBinder, OpsTenantSearchBinder>()));
             services.AddScoped
             (
                 _ => new MyDbContext

--- a/WebAPI.OData.EF6/WebAPI.OData.EF6.csproj
+++ b/WebAPI.OData.EF6/WebAPI.OData.EF6.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.AspNetCore.OData.EF6" Version="2.2.3-alpha.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\AutoMapper.AspNetCore.OData.EF6\AutoMapper.AspNetCore.OData.EF6.csproj" />
     <ProjectReference Include="..\DAL.EF6\DAL.EF6.csproj" />
     <ProjectReference Include="..\Domain.OData\Domain.OData.csproj" />
   </ItemGroup>

--- a/WebAPI.OData.EFCore/Binders/OpsTenantSearchBinder.cs
+++ b/WebAPI.OData.EFCore/Binders/OpsTenantSearchBinder.cs
@@ -4,14 +4,15 @@ using Domain.OData;
 using Microsoft.AspNetCore.OData.Query.Expressions;
 using Microsoft.OData.UriParser;
 
-namespace WebAPI.OData.EFCore.Binders;
-
-public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
+namespace WebAPI.OData.EFCore.Binders
 {
-    public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+    public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
     {
-        SearchTermNode node = searchClause.Expression as SearchTermNode;
-        Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
-        return exp;
+        public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+        {
+            SearchTermNode node = searchClause.Expression as SearchTermNode;
+            Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
+            return exp;
+        }
     }
 }

--- a/WebAPI.OData.EFCore/Binders/OpsTenantSearchBinder.cs
+++ b/WebAPI.OData.EFCore/Binders/OpsTenantSearchBinder.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq.Expressions;
+using Domain.OData;
+using Microsoft.AspNetCore.OData.Query.Expressions;
+using Microsoft.OData.UriParser;
+
+namespace WebAPI.OData.EFCore.Binders;
+
+public class OpsTenantSearchBinder : QueryBinder, ISearchBinder
+{
+    public Expression BindSearch(SearchClause searchClause, QueryBinderContext context)
+    {
+        SearchTermNode node = searchClause.Expression as SearchTermNode;
+        Expression<Func<OpsTenant, bool>> exp = p => p.Name == node.Text;
+        return exp;
+    }
+}

--- a/WebAPI.OData.EFCore/Properties/launchSettings.json
+++ b/WebAPI.OData.EFCore/Properties/launchSettings.json
@@ -19,9 +19,9 @@
     },
     "WebAPI.OData.EFCore": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "launchUrl": "api/values",
-      "applicationUrl": "http://localhost:5000",
+      "applicationUrl": "http://localhost:16324",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/WebAPI.OData.EFCore/Startup.cs
+++ b/WebAPI.OData.EFCore/Startup.cs
@@ -4,11 +4,14 @@ using Domain.OData;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Query.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
+using WebAPI.OData.EFCore.Binders;
+using WebAPI.OData.EFCore.Mappings;
 
 namespace WebAPI.OData.EFCore
 {
@@ -26,8 +29,9 @@ namespace WebAPI.OData.EFCore
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddDbContext<MyDbContext>(options => options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
-            services.AddControllers().AddOData(opt => opt.AddRouteComponents("", GetEdmModel()).Count().Filter().OrderBy().Expand().Select().SetMaxTop(null));
-
+            services.AddControllers()
+                .AddOData(opt => opt.EnableQueryFeatures()
+                    .AddRouteComponents("", GetEdmModel(), services => services.AddSingleton<ISearchBinder, OpsTenantSearchBinder>()));
             services.AddSingleton<AutoMapper.IConfigurationProvider>
             (
                 new MapperConfiguration(cfg =>

--- a/WebAPI.OData.EFCore/WebAPI.OData.EFCore.csproj
+++ b/WebAPI.OData.EFCore/WebAPI.OData.EFCore.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.AspNetCore.OData.EFCore" Version="2.2.3-alpha.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\AutoMapper.AspNetCore.OData.EFCore\AutoMapper.AspNetCore.OData.EFCore.csproj" />
     <ProjectReference Include="..\DAL.EFCore\DAL.EFCore.csproj" />
     <ProjectReference Include="..\Domain.OData\Domain.OData.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Implements support for $search clause from odata query options which was discussed here #118.  

Brief explanation: 
 If user defines search binder, map his expression and use it in filter. If $search and $filter are defined at the same time, both filters must be applied.