### PR TITLE
Adds support for $skip and $top with no order specified

### DIFF
--- a/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
+++ b/AutoMapper.AspNetCore.OData.EF6/AutoMapper.AspNetCore.OData.EF6.csproj
@@ -34,8 +34,10 @@
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\EdmTypeStructure.cs" Link="EdmTypeStructure.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\FilterHelper.cs" Link="FilterHelper.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\LinqExtensions.cs" Link="LinqExtensions.cs" />
+    <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\ODataQueryContextExtentions.cs" Link="ODataQueryContextExtentions.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\ODataQueryOptionsExtensions.cs" Link="ODataQueryOptionsExtensions.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\ODataSettings.cs" Link="ODataSettings.cs" />
+    <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\OrderBySetting.cs" Link="OrderBySetting.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\ProjectionSettings.cs" Link="ProjectionSettings.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\Properties\Resources.Designer.cs" Link="Properties\Resources.Designer.cs" />
     <Compile Include="..\AutoMapper.AspNetCore.OData.EFCore\QuerySettings.cs" Link="QuerySettings.cs" />

--- a/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
@@ -181,7 +181,7 @@ namespace AutoMapper.AspNet.OData
                     .BuildIncludes<TModel>(options.SelectExpand.GetSelects())
                     .ToList(),
                 querySettings?.ProjectionSettings
-            ).UpdateQueryableExpression(expansions);
+            ).UpdateQueryableExpression(expansions, options.Context);
         }
 
         private static IQueryable<TModel> GetQuery<TModel, TData>(this IQueryable<TData> query,

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -163,7 +163,7 @@ namespace AutoMapper.AspNet.OData
 
             if (orderByClause is null && (skip is not null || top is not null))
             {                       
-                var orderBySettings = type.FindSortableProperties(context);
+                var orderBySettings = context.FindSortableProperties(type);
 
                 if (orderBySettings is null)
                     return null;

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -123,18 +123,18 @@ namespace AutoMapper.AspNet.OData
             );
         }
 
-        public static Expression GetOrderByMethod<T>(this Expression expression, 
+        public static Expression GetOrderByMethod<T>(this Expression expression,
             ODataQueryOptions<T> options, ODataSettings oDataSettings = null)
-        {            
-            if ( NoQueryableMethod( options, oDataSettings ) )
+        {
+            if (NoQueryableMethod(options, oDataSettings))
                 return null;
 
             return expression.GetQueryableMethod
             (
                 options.OrderBy?.OrderByClause,
-                typeof( T ),
+                typeof(T),
                 options.Skip?.Value,
-                GetPageSize( )
+                GetPageSize()
             );
 
             int? GetPageSize()
@@ -151,31 +151,25 @@ namespace AutoMapper.AspNet.OData
                     ? options.Top.Value
                     : oDataSettings.PageSize;
             }
-        }
+        }        
 
-        private static bool NoQueryableMethod( ODataQueryOptions options, ODataSettings oDataSettings )
-            => options.OrderBy is null
-            && options.Top is null
-            && options.Skip is null
-            && oDataSettings?.PageSize is null;
-
-        public static Expression GetQueryableMethod(this Expression expression, 
-            OrderByClause orderByClause, Type type, int? skip, int? top )
+        public static Expression GetQueryableMethod(this Expression expression,
+            OrderByClause orderByClause, Type type, int? skip, int? top)
         {
-            if ( orderByClause is null && skip is null && top is null )
+            if (orderByClause is null && skip is null && top is null)
                 return null;
 
-            if (orderByClause is null && ( skip is not null || top is not null ) )
+            if (orderByClause is null && (skip is not null || top is not null))
             {
-                var propertyName = type.FirstSortableProperty( );
+                var propertyName = type.FirstSortableProperty();
 
-                if ( propertyName is null )
+                if (propertyName is null)
                     return null;
 
                 return expression
-                    .GetOrderByCall( propertyName, nameof( Queryable.OrderBy ) )
-                    .GetSkipCall( skip )
-                    .GetTakeCall( top );
+                    .GetOrderByCall(propertyName, nameof(Queryable.OrderBy))
+                    .GetSkipCall(skip)
+                    .GetTakeCall(top);
             }
 
             return expression
@@ -183,6 +177,12 @@ namespace AutoMapper.AspNet.OData
                 .GetSkipCall(skip)
                 .GetTakeCall(top);
         }
+
+        private static bool NoQueryableMethod(ODataQueryOptions options, ODataSettings oDataSettings)
+            => options.OrderBy is null
+            && options.Top is null
+            && options.Skip is null
+            && oDataSettings?.PageSize is null;
 
         private static Expression GetOrderByCall(this Expression expression, OrderByClause orderByClause)
         {
@@ -209,9 +209,6 @@ namespace AutoMapper.AspNet.OData
                         );
                     default:
                         SingleValuePropertyAccessNode propertyNode = (SingleValuePropertyAccessNode)orderByNode;
-                        var path = propertyNode.GetPropertyPath( );
-                        var range = orderByClause.RangeVariable.Name;
-
                         return expression.GetOrderByCall
                         (
                             propertyNode.GetPropertyPath(),

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -155,8 +155,7 @@ namespace AutoMapper.AspNet.OData
         }        
 
         public static Expression GetQueryableMethod(this Expression expression,
-            ODataQueryContext context,
-            OrderByClause orderByClause, Type type, int? skip, int? top)
+            ODataQueryContext context, OrderByClause orderByClause, Type type, int? skip, int? top)
         {
             if (orderByClause is null && skip is null && top is null)
                 return null;

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -2,11 +2,9 @@
 using LogicBuilder.Expressions.Utils;
 using LogicBuilder.Expressions.Utils.Expansions;
 using Microsoft.AspNetCore.OData.Query;
-using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -156,7 +156,7 @@ namespace AutoMapper.AspNet.OData
 
         public static Expression GetQueryableMethod(this Expression expression,
             ODataQueryContext context, OrderByClause orderByClause, Type type, int? skip, int? top)
-        {
+        {            
             if (orderByClause is null && skip is null && top is null)
                 return null;
 

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -166,7 +166,7 @@ namespace AutoMapper.AspNet.OData
                     return null;
 
                return expression
-                   .GetOrderByCall(orderBySettings)
+                   .GetDefaultOrderByCall(orderBySettings)
                    .GetSkipCall(skip)
                    .GetTakeCall(top);
             }
@@ -184,21 +184,21 @@ namespace AutoMapper.AspNet.OData
             && oDataSettings?.PageSize is null;
 
 
-        private static Expression GetThenByCall(this Expression expression, OrderBySetting settings)
+        private static Expression GetDefaultThenByCall(this Expression expression, OrderBySetting settings)
         {
             return settings.ThenBy is null
                 ? GetMethodCall()
-                : GetMethodCall().GetThenByCall(settings.ThenBy);
+                : GetMethodCall().GetDefaultThenByCall(settings.ThenBy);
 
             Expression GetMethodCall() =>
                 expression.GetOrderByCall(settings.Name, nameof(Queryable.ThenBy));
         }
 
-        private static Expression GetOrderByCall(this Expression expression, OrderBySetting settings)
+        private static Expression GetDefaultOrderByCall(this Expression expression, OrderBySetting settings)
         {
             return settings.ThenBy is null 
                 ? GetMethodCall()
-                : GetMethodCall().GetThenByCall(settings.ThenBy);
+                : GetMethodCall().GetDefaultThenByCall(settings.ThenBy);
 
             Expression GetMethodCall() => 
                 expression.GetOrderByCall(settings.Name, nameof(Queryable.OrderBy));            

--- a/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
@@ -9,6 +9,8 @@ namespace AutoMapper.AspNet.OData
     {
         public static OrderBySetting FindSortableProperties(this ODataQueryContext context, Type type)
         {
+            context = context ?? throw new ArgumentNullException(nameof(context));
+
             if (context.ElementType is IEdmEntityType parent)
             {
                 if (parent.FullName().Equals(type.FullName, StringComparison.Ordinal))

--- a/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
@@ -13,7 +13,7 @@ namespace AutoMapper.AspNet.OData
 
             if (context.ElementType is IEdmEntityType parent)
             {
-                if (parent.FullName().Equals(type.FullName, StringComparison.Ordinal))
+                if (parent.Name.Equals(type.Name, StringComparison.Ordinal))
                     return FindProperties(parent);
 
                 var child = FindEntity(type, parent);
@@ -34,7 +34,7 @@ namespace AutoMapper.AspNet.OData
                 if (props.Any())
                 {
                     var found = props.FirstOrDefault(p =>
-                        p.FullName().Equals(type.FullName, StringComparison.Ordinal));
+                        p.Name.Equals(type.Name, StringComparison.Ordinal));
 
                     if (found is not null)
                         return found;

--- a/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.AspNetCore.OData.Query;
+using Microsoft.OData.Edm;
+using System;
+using System.Linq;
+
+namespace AutoMapper.AspNet.OData
+{
+    internal static class ODataQueryContextExtentions
+    {
+        public static OrderBySetting FindSortableProperties(this ODataQueryContext context, Type type)
+        {
+            if (context.ElementType is IEdmEntityType parent)
+            {
+                if (parent.FullName().Equals(type.FullName, StringComparison.Ordinal))
+                    return FindProperties(parent);
+
+                var child = FindEntity(type, parent);
+                if (child is not null)
+                    return FindProperties(child);
+            }
+            return null;
+
+            static IEdmEntityType FindEntity(Type type, IEdmEntityType declaringType)
+            {
+                var props = declaringType.DeclaredProperties
+                    .Where(p => p.Type.Definition is IEdmCollectionType)
+                    .Select(p => (IEdmCollectionType)p.Type.Definition)
+                    .Where(p => p.ElementType.Definition is IEdmEntityType)
+                    .Select(p => (IEdmEntityType)p.ElementType.Definition)
+                    .Distinct();
+
+                if (props.Any())
+                {
+                    var found = props.FirstOrDefault(p =>
+                        p.FullName().Equals(type.FullName, StringComparison.Ordinal));
+
+                    if (found is not null)
+                        return found;
+
+                    foreach (var prop in props)
+                    {
+                        return FindEntity(type, prop);
+                    }
+                }
+                return null;
+            }
+
+            static OrderBySetting FindProperties(IEdmEntityType entity)
+            {
+                var properties = entity.Key().Any() switch
+                {
+                    true => entity.Key().Select(k => k.Name),
+                    false => entity.StructuralProperties()
+                        .Where(p => p.Type.IsPrimitive() && !p.Type.IsStream())
+                        .Select(p => p.Name)
+                        .OrderBy(n => n)
+                        .Take(1)
+                };
+                var orderBySettings = new OrderBySetting();
+                properties.Aggregate(orderBySettings, (settings, prop) =>
+                {
+                    if (settings.Name is null)
+                    {
+                        settings.Name = prop;
+                        return settings;
+                    }
+                    settings.ThenBy = new() { Name = prop };
+                    return settings.ThenBy;
+                });
+                return orderBySettings.Name is null ? null : orderBySettings;
+            }
+
+        }
+    }
+}

--- a/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
@@ -11,41 +11,9 @@ namespace AutoMapper.AspNet.OData
         {
             context = context ?? throw new ArgumentNullException(nameof(context));
 
-            if (context.ElementType is IEdmEntityType parent)
-            {
-                if (parent.Name.Equals(type.Name, StringComparison.Ordinal))
-                    return FindProperties(parent);
+            var entity = context.Model.FindDeclaredType(type.FullName) as IEdmEntityType;
+            return entity is not null ? FindProperties(entity) : null;
 
-                var child = FindEntity(type, parent);
-                if (child is not null)
-                    return FindProperties(child);
-            }
-            return null;
-
-            static IEdmEntityType FindEntity(Type type, IEdmEntityType declaringType)
-            {
-                var props = declaringType.DeclaredProperties
-                    .Where(p => p.Type.Definition is IEdmCollectionType)
-                    .Select(p => (IEdmCollectionType)p.Type.Definition)
-                    .Where(p => p.ElementType.Definition is IEdmEntityType)
-                    .Select(p => (IEdmEntityType)p.ElementType.Definition)
-                    .Distinct();
-
-                if (props.Any())
-                {
-                    var found = props.FirstOrDefault(p =>
-                        p.Name.Equals(type.Name, StringComparison.Ordinal));
-
-                    if (found is not null)
-                        return found;
-
-                    foreach (var prop in props)
-                    {
-                        return FindEntity(type, prop);
-                    }
-                }
-                return null;
-            }
 
             static OrderBySetting FindProperties(IEdmEntityType entity)
             {

--- a/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
@@ -12,7 +12,9 @@ namespace AutoMapper.AspNet.OData
             context = context ?? throw new ArgumentNullException(nameof(context));
 
             var entity = context.Model.FindDeclaredType(type.FullName) as IEdmEntityType;
-            return entity is not null ? FindProperties(entity) : null;
+            return entity is not null 
+                ? FindProperties(entity) 
+                : throw new InvalidOperationException($"The type '{type.FullName}' has not been declared in the entity data model.");
 
 
             static OrderBySetting FindProperties(IEdmEntityType entity)

--- a/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/ODataQueryContextExtentions.cs
@@ -49,7 +49,7 @@ namespace AutoMapper.AspNet.OData
 
             static OrderBySetting FindProperties(IEdmEntityType entity)
             {
-                var properties = entity.Key().Any() switch
+                var propertyNames = entity.Key().Any() switch
                 {
                     true => entity.Key().Select(k => k.Name),
                     false => entity.StructuralProperties()
@@ -59,14 +59,14 @@ namespace AutoMapper.AspNet.OData
                         .Take(1)
                 };
                 var orderBySettings = new OrderBySetting();
-                properties.Aggregate(orderBySettings, (settings, prop) =>
+                propertyNames.Aggregate(orderBySettings, (settings, name) =>
                 {
                     if (settings.Name is null)
                     {
-                        settings.Name = prop;
+                        settings.Name = name;
                         return settings;
                     }
-                    settings.ThenBy = new() { Name = prop };
+                    settings.ThenBy = new() { Name = name };
                     return settings.ThenBy;
                 });
                 return orderBySettings.Name is null ? null : orderBySettings;

--- a/AutoMapper.AspNetCore.OData.EFCore/OrderBySetting.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/OrderBySetting.cs
@@ -1,0 +1,8 @@
+﻿namespace AutoMapper.AspNet.OData
+{
+    internal class OrderBySetting
+    {
+        public string Name { get; set; }
+        public OrderBySetting ThenBy { get; set; }
+    }
+}

--- a/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
@@ -126,6 +126,7 @@ namespace AutoMapper.AspNet.OData
             Expression<Func<TModel, bool>> filter)
             where TModel : class
         {
+            
             var expansions = options.SelectExpand.GetExpansions(typeof(TModel));
 
             return query.GetQuery

--- a/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
@@ -33,7 +33,7 @@ namespace AutoMapper.AspNet.OData
 
         public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
-        {
+        {            
             Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(
                 querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
                 querySettings?.ODataSettings?.TimeZone);
@@ -139,7 +139,7 @@ namespace AutoMapper.AspNet.OData
                     .BuildIncludes<TModel>(options.SelectExpand.GetSelects())
                     .ToList(),
                 querySettings?.ProjectionSettings
-            ).UpdateQueryableExpression(expansions);
+            ).UpdateQueryableExpression(expansions, options.Context);
         }
 
         private static IQueryable<TModel> GetQuery<TModel, TData>(this IQueryable<TData> query,

--- a/AutoMapper.AspNetCore.OData.EFCore/TypeExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/TypeExtensions.cs
@@ -16,8 +16,9 @@ namespace AutoMapper.AspNet.OData
                 .GetProperties( BindingFlags.Public | BindingFlags.Instance )
                 .Where( p => p.PropertyType.IsLiteralType( ) );
 
+            var attributeType = typeof(KeyAttribute);
             var property = allProperties
-                .FirstOrDefault( p => Attribute.IsDefined( p, typeof( KeyAttribute ) ) );
+                .FirstOrDefault( p => Attribute.IsDefined( p, attributeType ) );
 
             if ( property is not null )
                 return property.Name;            

--- a/AutoMapper.AspNetCore.OData.EFCore/TypeExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/TypeExtensions.cs
@@ -2,6 +2,7 @@
 using Microsoft.OData.Edm;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 
@@ -9,6 +10,37 @@ namespace AutoMapper.AspNet.OData
 {
     internal static class TypeExtensions
     {
+        public static string FirstSortableProperty( this Type type )
+        {            
+            if ( !type.IsClass )
+            {
+                throw new ArgumentException( "type" );
+            }
+
+            var allProperties = type
+                .GetProperties( BindingFlags.Public | BindingFlags.Instance )
+                .Where( p => p.PropertyType.IsLiteralType( ) );
+
+            var property = allProperties
+                .FirstOrDefault( p => Attribute.IsDefined( p, typeof( KeyAttribute ) ) );
+
+            if ( property is not null )
+            {
+                return property.Name;
+            }
+
+            property = allProperties
+                .SingleOrDefault( p => p.Name.Equals( "ID", StringComparison.OrdinalIgnoreCase )
+                    || p.Name.Contains( $"{type.Name}ID", StringComparison.OrdinalIgnoreCase ) );
+
+            if ( property is not null )
+            {
+                return property.Name;
+            }
+
+            return allProperties.FirstOrDefault( )?.Name;
+        }
+
         public static MemberInfo[] GetSelectedMembers(this Type parentType, List<string> selects)
         {
             if (selects == null || !selects.Any())

--- a/AutoMapper.AspNetCore.OData.EFCore/TypeExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/TypeExtensions.cs
@@ -12,11 +12,6 @@ namespace AutoMapper.AspNet.OData
     {
         public static string FirstSortableProperty( this Type type )
         {            
-            if ( !type.IsClass )
-            {
-                throw new ArgumentException( "type" );
-            }
-
             var allProperties = type
                 .GetProperties( BindingFlags.Public | BindingFlags.Instance )
                 .Where( p => p.PropertyType.IsLiteralType( ) );
@@ -25,18 +20,14 @@ namespace AutoMapper.AspNet.OData
                 .FirstOrDefault( p => Attribute.IsDefined( p, typeof( KeyAttribute ) ) );
 
             if ( property is not null )
-            {
-                return property.Name;
-            }
+                return property.Name;            
 
-            property = allProperties
-                .SingleOrDefault( p => p.Name.Equals( "ID", StringComparison.OrdinalIgnoreCase )
-                    || p.Name.Contains( $"{type.Name}ID", StringComparison.OrdinalIgnoreCase ) );
+            property = allProperties.SingleOrDefault( p => 
+                p.Name.Equals( "ID", StringComparison.OrdinalIgnoreCase )
+                || p.Name.Equals( $"{type.Name}ID", StringComparison.OrdinalIgnoreCase ) );
 
-            if ( property is not null )
-            {
-                return property.Name;
-            }
+            if ( property is not null )            
+                return property.Name;            
 
             return allProperties.FirstOrDefault( )?.Name;
         }

--- a/AutoMapper.AspNetCore.OData.EFCore/TypeExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/TypeExtensions.cs
@@ -10,79 +10,8 @@ using System.Reflection;
 
 namespace AutoMapper.AspNet.OData
 {
-    internal class OrderBySetting
-    {
-        public string Name { get; set; }
-        public OrderBySetting ThenBy { get; set; }
-    }
-
     internal static class TypeExtensions
     {
-        public static OrderBySetting FindSortableProperties(this Type type, ODataQueryContext context)
-        {
-            if (context.ElementType is IEdmEntityType parent)
-            {                
-                if (parent.FullName().Equals(type.FullName, StringComparison.Ordinal))                
-                    return FindProperties(parent);
-                
-                var child = FindEntity(type, parent);
-                if (child is not null)           
-                    return FindProperties(child);                           
-            }
-            return null;
-
-            static IEdmEntityType FindEntity(Type type, IEdmEntityType declaringType)
-            {
-                var props = declaringType.DeclaredProperties
-                    .Where(p => p.Type.Definition is IEdmCollectionType)
-                    .Select(p => (IEdmCollectionType)p.Type.Definition)
-                    .Where(p => p.ElementType.Definition is IEdmEntityType)
-                    .Select(p => (IEdmEntityType)p.ElementType.Definition)
-                    .Distinct();
-
-                if (props.Any())
-                {
-                    var found = props.FirstOrDefault(p => 
-                        p.FullName().Equals(type.FullName, StringComparison.Ordinal));
-
-                    if (found is not null)
-                        return found;
-                    
-                    foreach (var prop in props)
-                    {
-                        return FindEntity(type, prop);
-                    }
-                }
-                return null;
-            }
-
-            static OrderBySetting FindProperties(IEdmEntityType entity)
-            {
-                var properties = entity.Key().Any() switch
-                {
-                    true => entity.Key().Select(k => k.Name),
-                    false => entity.StructuralProperties()
-                        .Where(p => p.Type.IsPrimitive() && !p.Type.IsStream())
-                        .Select(p => p.Name)
-                        .OrderBy(n => n)
-                        .Take(1)
-                };
-                var orderBySettings = new OrderBySetting();
-                properties.Aggregate(orderBySettings, (settings, prop) =>
-                {
-                    if (settings.Name is null)
-                    {
-                        settings.Name = prop;
-                        return settings;
-                    }
-                    settings.ThenBy = new() { Name = prop };
-                    return settings.ThenBy;
-                });
-                return orderBySettings.Name is null ? null : orderBySettings;
-            }            
-                            
-        }
-
         public static MemberInfo[] GetSelectedMembers(this Type parentType, List<string> selects)
         {
             if (selects == null || !selects.Any())

--- a/AutoMapper.AspNetCore.OData.EFCore/Visitors/ChildCollectionOrderByUpdater.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Visitors/ChildCollectionOrderByUpdater.cs
@@ -1,9 +1,7 @@
-﻿using Microsoft.OData.Edm;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace AutoMapper.AspNet.OData.Visitors
 {

--- a/AutoMapper.AspNetCore.OData.EFCore/Visitors/ChildCollectionOrderByUpdater.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Visitors/ChildCollectionOrderByUpdater.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.OData.Query;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -6,26 +7,31 @@ using System.Linq.Expressions;
 namespace AutoMapper.AspNet.OData.Visitors
 {
     internal class ChildCollectionOrderByUpdater : ProjectionVisitor
-    {        
-        public ChildCollectionOrderByUpdater(List<ODataExpansionOptions> expansions) 
-            : base(expansions)
-        { }
+    {
+        private readonly ODataQueryContext context;
 
-        public static Expression UpdaterExpansion(Expression expression, List<ODataExpansionOptions> expansions)
-                => new ChildCollectionOrderByUpdater(expansions).Visit(expression);
+        public ChildCollectionOrderByUpdater(List<ODataExpansionOptions> expansions, ODataQueryContext context) 
+            : base(expansions)
+        {
+            this.context = context;
+        }
+
+        public static Expression UpdaterExpansion(Expression expression, List<ODataExpansionOptions> expansions, ODataQueryContext context)
+                => new ChildCollectionOrderByUpdater(expansions, context).Visit(expression);
 
         protected override Expression GetBindingExpression(MemberAssignment binding, ODataExpansionOptions expansion)
         {
             if (expansion.QueryOptions != null)
             {
-                return MethodAppender.AppendQueryMethod(binding.Expression, expansion);
+                return MethodAppender.AppendQueryMethod(binding.Expression, expansion, context);
             }
             else if (expansions.Count > 1)  //Mutually exclusive with expansion.QueryOptions != null.                            
             {                               //There can be only one set of QueryOptions in the list.  See the GetQueryMethods() method in QueryableExtensions.UpdateQueryable.
                 return UpdaterExpansion
-                (
+                (                             
                     binding.Expression,
-                    expansions.Skip(1).ToList()
+                    expansions.Skip(1).ToList(),
+                    context
                 );
             }
             else

--- a/AutoMapper.AspNetCore.OData.EFCore/Visitors/ChildCollectionOrderByUpdater.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Visitors/ChildCollectionOrderByUpdater.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.OData.Edm;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -7,10 +8,10 @@ using System.Text;
 namespace AutoMapper.AspNet.OData.Visitors
 {
     internal class ChildCollectionOrderByUpdater : ProjectionVisitor
-    {
-        public ChildCollectionOrderByUpdater(List<ODataExpansionOptions> expansions) : base(expansions)
-        {
-        }
+    {        
+        public ChildCollectionOrderByUpdater(List<ODataExpansionOptions> expansions) 
+            : base(expansions)
+        { }
 
         public static Expression UpdaterExpansion(Expression expression, List<ODataExpansionOptions> expansions)
                 => new ChildCollectionOrderByUpdater(expansions).Visit(expression);

--- a/AutoMapper.AspNetCore.OData.EFCore/Visitors/MethodAppender.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Visitors/MethodAppender.cs
@@ -1,4 +1,5 @@
 ﻿using LogicBuilder.Expressions.Utils;
+using Microsoft.OData.Edm;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
@@ -11,7 +12,7 @@ namespace AutoMapper.AspNet.OData.Visitors
         public MethodAppender(Expression expression, ODataExpansionOptions expansion)
         {
             this.expansion = expansion;
-            this.expression = expression;
+            this.expression = expression;            
         }
 
         private readonly ODataExpansionOptions expansion;
@@ -26,7 +27,7 @@ namespace AutoMapper.AspNet.OData.Visitors
             if (node.Method.Name == "Select"
                 && elementType == node.Type.GetUnderlyingElementType()
                 && this.expression.ToString().StartsWith(node.ToString()))//makes sure we're not updating some nested "Select"
-            {
+            {                                
                 return node.GetQueryableMethod
                 (
                     expansion.QueryOptions.OrderByClause,

--- a/AutoMapper.AspNetCore.OData.EFCore/Visitors/MethodAppender.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Visitors/MethodAppender.cs
@@ -12,7 +12,7 @@ namespace AutoMapper.AspNet.OData.Visitors
         public MethodAppender(Expression expression, ODataExpansionOptions expansion)
         {
             this.expansion = expansion;
-            this.expression = expression;            
+            this.expression = expression;
         }
 
         private readonly ODataExpansionOptions expansion;
@@ -27,7 +27,7 @@ namespace AutoMapper.AspNet.OData.Visitors
             if (node.Method.Name == "Select"
                 && elementType == node.Type.GetUnderlyingElementType()
                 && this.expression.ToString().StartsWith(node.ToString()))//makes sure we're not updating some nested "Select"
-            {                                
+            {
                 return node.GetQueryableMethod
                 (
                     expansion.QueryOptions.OrderByClause,

--- a/AutoMapper.AspNetCore.OData.EFCore/Visitors/MethodAppender.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Visitors/MethodAppender.cs
@@ -1,4 +1,5 @@
 ﻿using LogicBuilder.Expressions.Utils;
+using Microsoft.AspNetCore.OData.Query;
 using System;
 using System.Linq.Expressions;
 
@@ -6,17 +7,20 @@ namespace AutoMapper.AspNet.OData.Visitors
 {
     internal class MethodAppender : ExpressionVisitor
     {
-        public MethodAppender(Expression expression, ODataExpansionOptions expansion)
+        private readonly ODataQueryContext context;
+
+        public MethodAppender(Expression expression, ODataExpansionOptions expansion, ODataQueryContext context)
         {
             this.expansion = expansion;
             this.expression = expression;
+            this.context = context;
         }
 
         private readonly ODataExpansionOptions expansion;
         private readonly Expression expression;
 
-        public static Expression AppendQueryMethod(Expression expression, ODataExpansionOptions expansion)
-            => new MethodAppender(expression, expansion).Visit(expression);
+        public static Expression AppendQueryMethod(Expression expression, ODataExpansionOptions expansion, ODataQueryContext context)
+            => new MethodAppender(expression, expansion, context).Visit(expression);
 
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
@@ -27,6 +31,7 @@ namespace AutoMapper.AspNet.OData.Visitors
             {
                 return node.GetQueryableMethod
                 (
+                    context,
                     expansion.QueryOptions.OrderByClause,
                     elementType,
                     expansion.QueryOptions.Skip,

--- a/AutoMapper.AspNetCore.OData.EFCore/Visitors/MethodAppender.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Visitors/MethodAppender.cs
@@ -1,9 +1,6 @@
 ﻿using LogicBuilder.Expressions.Utils;
-using Microsoft.OData.Edm;
 using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace AutoMapper.AspNet.OData.Visitors
 {

--- a/AutoMapper.OData.EF6.Tests/Data/DataClasses.cs
+++ b/AutoMapper.OData.EF6.Tests/Data/DataClasses.cs
@@ -58,13 +58,17 @@ namespace AutoMapper.OData.EF6.Tests.Data
     {
         public int CategoryID { get; set; }
         public string CategoryName { get; set; }
-
         public Product Product { get; set; }
-
         public ICollection<Product> Products { get; set; }
-
+        public ICollection<CompositeKey> CompositeKeys { get; set; }
         public IEnumerable<Product> EnumerableProducts { get; set; }
         public IQueryable<Product> QueryableProducts { get; set; }
+    }
+
+    public class CompositeKey
+    {
+        public int ID1 { get; set; }
+        public int ID2 { get; set; }
     }
 
     public class Address

--- a/AutoMapper.OData.EF6.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EF6.Tests/GetQueryTests.cs
@@ -660,6 +660,14 @@ Result Message:	System.NotSupportedException : The type 'Domain.OData.CoreBuildi
                             AlternateAddresses = Array.Empty<Address>( ),
                             SupplierAddress = new Address { City = "C" }
                         },
+                    },
+                    CompositeKeys = new CompositeKey[]
+                    {
+                        new CompositeKey{ ID1 = 1, ID2 = 5 },
+                        new CompositeKey{ ID1 = 1, ID2 = 4 },
+                        new CompositeKey{ ID1 = 1, ID2 = 3 },
+                        new CompositeKey{ ID1 = 1, ID2 = 2 },
+                        new CompositeKey{ ID1 = 1, ID2 = 1 },
                     }
                 },
                 new Category
@@ -687,6 +695,14 @@ Result Message:	System.NotSupportedException : The type 'Domain.OData.CoreBuildi
                             },
                             SupplierAddress = new Address { City = "E" }
                         }
+                    },
+                    CompositeKeys = new CompositeKey[]
+                    {
+                        new CompositeKey{ ID1 = 1, ID2 = 9 },
+                        new CompositeKey{ ID1 = 2, ID2 = 5 },
+                        new CompositeKey{ ID1 = 2, ID2 = 2 },
+                        new CompositeKey{ ID1 = 3, ID2 = 3 },
+                        new CompositeKey{ ID1 = 3, ID2 = 4 },
                     }
                 }
             }.AsQueryable();
@@ -889,6 +905,7 @@ Result Message:	System.NotSupportedException : The type 'Domain.OData.CoreBuildi
         {
             const string query = "/CategoryModel?$skip=1&$expand=Products($skip=1;$expand=AlternateAddresses($skip=1;$top=3;$orderby=AddressID desc))";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {
@@ -907,6 +924,7 @@ Result Message:	System.NotSupportedException : The type 'Domain.OData.CoreBuildi
         {
             const string query = "/CategoryModel?$skip=1&$expand=Products($skip=1;$expand=AlternateAddresses($skip=1;$top=3))";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {
@@ -925,6 +943,7 @@ Result Message:	System.NotSupportedException : The type 'Domain.OData.CoreBuildi
         {
             const string query = "/CategoryModel?$expand=Products($skip=1;$top=2)";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {
@@ -940,6 +959,7 @@ Result Message:	System.NotSupportedException : The type 'Domain.OData.CoreBuildi
         {
             const string query = "/CategoryModel?$expand=Products($skip=3)";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {
@@ -949,10 +969,57 @@ Result Message:	System.NotSupportedException : The type 'Domain.OData.CoreBuildi
         }
 
         [Fact]
+        public async void ExpandChildCollectionWithSkipNoOrderByModelHasCompositeKey()
+        {
+            const string query = "/CategoryModel?$expand=CompositeKeys($skip=1)";
+            Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
+
+            static void Test(ICollection<CategoryModel> collection)
+            {
+                var first = collection.First().CompositeKeys.ToArray();
+                Assert.Equal(4, first.Length);
+                Assert.Equal((1, 2), (first[0].ID1, first[0].ID2));
+                Assert.Equal((1, 3), (first[1].ID1, first[1].ID2));
+                Assert.Equal((1, 4), (first[2].ID1, first[2].ID2));
+                Assert.Equal((1, 5), (first[3].ID1, first[3].ID2));
+
+                var second = collection.Last().CompositeKeys.ToArray();
+                Assert.Equal(4, second.Length);
+                Assert.Equal((2, 2), (second[0].ID1, second[0].ID2));
+                Assert.Equal((2, 5), (second[1].ID1, second[1].ID2));
+                Assert.Equal((3, 3), (second[2].ID1, second[2].ID2));
+                Assert.Equal((3, 4), (second[3].ID1, second[3].ID2));
+            }
+        }
+
+        [Fact]
+        public async void ExpandChildCollectionWithSkipAndTopNoOrderByModelHasCompositeKey()
+        {
+            const string query = "/CategoryModel?$expand=CompositeKeys($skip=1;$top=2)";
+            Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
+
+            static void Test(ICollection<CategoryModel> collection)
+            {
+                var first = collection.First().CompositeKeys.ToArray();
+                Assert.Equal(2, first.Length);
+                Assert.Equal((1, 2), (first[0].ID1, first[0].ID2));
+                Assert.Equal((1, 3), (first[1].ID1, first[1].ID2));
+
+                var second = collection.Last().CompositeKeys.ToArray();
+                Assert.Equal(2, second.Length);
+                Assert.Equal((2, 2), (second[0].ID1, second[0].ID2));
+                Assert.Equal((2, 5), (second[1].ID1, second[1].ID2));
+            }
+        }
+
+        [Fact]
         public async void SkipOnRootNoOrderBy()
         {
             const string query = "/CategoryModel?$skip=1";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {
@@ -966,6 +1033,7 @@ Result Message:	System.NotSupportedException : The type 'Domain.OData.CoreBuildi
         {
             const string query = "/CategoryModel?$skip=2";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {

--- a/AutoMapper.OData.EF6.Tests/Mappings/ObjectMappings.cs
+++ b/AutoMapper.OData.EF6.Tests/Mappings/ObjectMappings.cs
@@ -21,6 +21,7 @@ namespace AutoMapper.OData.EF6.Tests.Mappings
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<Product, ProductModel>()
                 .ForAllMembers(o => o.ExplicitExpansion());
+            CreateMap<CompositeKey, CompositeKeyModel>();
         }
     }
 }

--- a/AutoMapper.OData.EF6.Tests/Model/ModelClasses.cs
+++ b/AutoMapper.OData.EF6.Tests/Model/ModelClasses.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Text;
 using System.Xml.Linq;
 
 namespace AutoMapper.OData.EF6.Tests.Model
@@ -13,7 +12,6 @@ namespace AutoMapper.OData.EF6.Tests.Model
     {
         [Key]
         public int ProductID { get; set; }
-
         public string ProductName { get; set; }
         public int SupplierID { get; set; }
         public int CategoryID { get; set; }
@@ -62,13 +60,19 @@ namespace AutoMapper.OData.EF6.Tests.Model
         [Key]
         public int CategoryID { get; set; }
         public string CategoryName { get; set; }
-
         public ProductModel Product { get; set; }
-
         public ICollection<ProductModel> Products { get; set; }
-
+        public ICollection<CompositeKeyModel> CompositeKeys { get; set; }
         public IEnumerable<ProductModel> EnumerableProducts { get; set; }
         public IQueryable<ProductModel> QueryableProducts { get; set; }
+    }
+
+    public class CompositeKeyModel
+    {
+        [Key]
+        public int ID1 { get; set; }
+        [Key]
+        public int ID2 { get; set; }
     }
 
     public class AddressModel

--- a/AutoMapper.OData.EFCore.Tests/Data/DataClasses.cs
+++ b/AutoMapper.OData.EFCore.Tests/Data/DataClasses.cs
@@ -11,7 +11,6 @@ namespace AutoMapper.OData.EFCore.Tests.Data
     public class Product
     {
         public int ProductID { get; set; }
-
         public string ProductName { get; set; }
         public int SupplierID { get; set; }
         public int CategoryID { get; set; }
@@ -64,8 +63,16 @@ namespace AutoMapper.OData.EFCore.Tests.Data
 
         public ICollection<Product> Products { get; set; }
 
+        public ICollection<CompositeKey> CompositeKeys { get; set; }
+
         public IEnumerable<Product> EnumerableProducts { get; set; }
         public IQueryable<Product> QueryableProducts { get; set; }
+    }
+
+    public class CompositeKey
+    {        
+        public int ID1 { get; set; }        
+        public int ID2 { get; set; }
     }
 
     public class Address

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -909,6 +909,32 @@ namespace AutoMapper.OData.EFCore.Tests
         }
 
         [Fact]
+        public async void SkipFirstResult_WithNoOrderByClause_ShouldReturnOrderedCollection( )
+        {
+            var query = "/corebuilding?$skip=1";
+            var options = ODataHelpers
+                .GetODataQueryOptions<CoreBuilding>( query, serviceProvider);
+
+            var skippedResults = await GetAsync<CoreBuilding, TBuilding>( query, options );
+
+            query = "/corebuilding";
+            options = ODataHelpers
+                .GetODataQueryOptions<CoreBuilding>( query, serviceProvider );
+
+            var allResults = await GetAsync<CoreBuilding, TBuilding>( query, options );
+
+            Assert.True( allResults.Count - skippedResults.Count == 1 );
+
+            //var skippedIds = skippedResults
+            //    .Select( r => r.Identity )
+            //    .ToList( );
+            //
+            //var allIds = allResults/*.OrderBy( r => r.Identity )*/
+            //    .Select( r => r.Identity )
+            //    .ToList( );
+        }
+
+        [Fact]
         public async Task CancellationThrowsException()
         {
             var cancelledToken = new CancellationTokenSource(TimeSpan.Zero).Token;

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -705,6 +705,14 @@ namespace AutoMapper.OData.EFCore.Tests
                             AlternateAddresses = Array.Empty<Address>( ),
                             SupplierAddress = new Address { City = "C" }
                         },
+                    },
+                    CompositeKeys = new CompositeKey[]
+                    {
+                        new CompositeKey{ ID1 = 1, ID2 = 5 },
+                        new CompositeKey{ ID1 = 1, ID2 = 4 },
+                        new CompositeKey{ ID1 = 1, ID2 = 3 },
+                        new CompositeKey{ ID1 = 1, ID2 = 2 },
+                        new CompositeKey{ ID1 = 1, ID2 = 1 },
                     }
                 },
                 new Category
@@ -732,6 +740,14 @@ namespace AutoMapper.OData.EFCore.Tests
                             },
                             SupplierAddress = new Address { City = "E" }
                         }
+                    },
+                    CompositeKeys = new CompositeKey[]
+                    {
+                        new CompositeKey{ ID1 = 1, ID2 = 9 },
+                        new CompositeKey{ ID1 = 2, ID2 = 5 },
+                        new CompositeKey{ ID1 = 2, ID2 = 2 },
+                        new CompositeKey{ ID1 = 3, ID2 = 3 },
+                        new CompositeKey{ ID1 = 3, ID2 = 4 },
                     }
                 }
             }.AsQueryable();
@@ -934,6 +950,7 @@ namespace AutoMapper.OData.EFCore.Tests
         {
             const string query = "/CategoryModel?$skip=1&$expand=Products($skip=1;$expand=AlternateAddresses($skip=1;$top=3;$orderby=AddressID desc))";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {
@@ -952,6 +969,7 @@ namespace AutoMapper.OData.EFCore.Tests
         {
             const string query = "/CategoryModel?$skip=1&$expand=Products($skip=1;$expand=AlternateAddresses($skip=1;$top=3))";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {
@@ -970,6 +988,7 @@ namespace AutoMapper.OData.EFCore.Tests
         {
             const string query = "/CategoryModel?$expand=Products($skip=1;$top=2)";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {
@@ -985,6 +1004,7 @@ namespace AutoMapper.OData.EFCore.Tests
         {
             const string query = "/CategoryModel?$expand=Products($skip=3)";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {
@@ -994,10 +1014,57 @@ namespace AutoMapper.OData.EFCore.Tests
         }
 
         [Fact]
+        public async void ExpandChildCollectionWithSkipNoOrderByModelHasCompositeKey()
+        {
+            const string query = "/CategoryModel?$expand=CompositeKeys($skip=1)";
+            Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
+
+            static void Test(ICollection<CategoryModel> collection)
+            {
+                var first = collection.First().CompositeKeys.ToArray();
+                Assert.Equal(4, first.Length);
+                Assert.Equal((1, 2), (first[0].ID1, first[0].ID2));
+                Assert.Equal((1, 3), (first[1].ID1, first[1].ID2));
+                Assert.Equal((1, 4), (first[2].ID1, first[2].ID2));
+                Assert.Equal((1, 5), (first[3].ID1, first[3].ID2));
+
+                var second = collection.Last().CompositeKeys.ToArray();
+                Assert.Equal(4, second.Length);
+                Assert.Equal((2, 2), (second[0].ID1, second[0].ID2));
+                Assert.Equal((2, 5), (second[1].ID1, second[1].ID2));
+                Assert.Equal((3, 3), (second[2].ID1, second[2].ID2));
+                Assert.Equal((3, 4), (second[3].ID1, second[3].ID2));
+            }
+        }
+
+        [Fact]
+        public async void ExpandChildCollectionWithSkipAndTopNoOrderByModelHasCompositeKey()
+        {
+            const string query = "/CategoryModel?$expand=CompositeKeys($skip=1;$top=2)";
+            Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
+
+            static void Test(ICollection<CategoryModel> collection)
+            {
+                var first = collection.First().CompositeKeys.ToArray();
+                Assert.Equal(2, first.Length);
+                Assert.Equal((1, 2), (first[0].ID1, first[0].ID2));
+                Assert.Equal((1, 3), (first[1].ID1, first[1].ID2));
+
+                var second = collection.Last().CompositeKeys.ToArray();
+                Assert.Equal(2, second.Length);
+                Assert.Equal((2, 2), (second[0].ID1, second[0].ID2));
+                Assert.Equal((2, 5), (second[1].ID1, second[1].ID2));
+            }
+        }
+
+        [Fact]
         public async void SkipOnRootNoOrderBy()
         {
             const string query = "/CategoryModel?$skip=1";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {
@@ -1011,6 +1078,7 @@ namespace AutoMapper.OData.EFCore.Tests
         {
             const string query = "/CategoryModel?$skip=2";
             Test(await GetAsync<CategoryModel, Category>(query, GetCategories()));
+            Test(Get<CategoryModel, Category>(query, GetCategories()));
 
             static void Test(ICollection<CategoryModel> collection)
             {

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -683,13 +683,6 @@ namespace AutoMapper.OData.EFCore.Tests
                     {
                         new Product
                         {
-                            ProductID = 3,
-                            ProductName = "ProductThree",
-                            AlternateAddresses = Array.Empty<Address>( ),
-                            SupplierAddress = new Address { City = "B" }
-                        },
-                        new Product
-                        {
                             ProductID = 1,
                             ProductName = "ProductOne",
                             AlternateAddresses = new Address[]
@@ -705,7 +698,14 @@ namespace AutoMapper.OData.EFCore.Tests
                             ProductName = "ProductTwo",
                             AlternateAddresses = Array.Empty<Address>( ),
                             SupplierAddress = new Address { City = "B" }
-                        }
+                        },
+                        new Product
+                        {
+                            ProductID = 3,
+                            ProductName = "ProductThree",
+                            AlternateAddresses = Array.Empty<Address>( ),
+                            SupplierAddress = new Address { City = "B" }
+                        },
                     }
                 },
                 new Category
@@ -773,7 +773,7 @@ namespace AutoMapper.OData.EFCore.Tests
             static void Test(ICollection<CategoryModel> collection)
             {
                 Assert.Equal(2, collection.Count);
-                Assert.Equal(2, collection.First().Products.Count);
+                Assert.Equal(3, collection.First().Products.Count);
             }
         }
 
@@ -855,7 +855,7 @@ namespace AutoMapper.OData.EFCore.Tests
             static void Test(ICollection<CategoryModel> collection)
             {
                 Assert.Equal(2, collection.Count);
-                Assert.Equal(2, collection.First().Products.Count);
+                Assert.Equal(3, collection.First().Products.Count);
                 Assert.Equal(2, collection.First().Products.First().AlternateAddresses.Count());
             }
         }
@@ -934,7 +934,7 @@ namespace AutoMapper.OData.EFCore.Tests
         }
 
         [Fact]
-        public async void SkipFirstResult_WithNoOrderByClause_ShouldReturnOrderedCollection( )
+        public async void SkipFirstResultOnRoot_WithNoOrderByClause_ShouldReturnOrderedCollection( )
         {
             var query = "/corebuilding?$skip=1";
             var options = ODataHelpers

--- a/AutoMapper.OData.EFCore.Tests/GetTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetTests.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using AutoMapper.OData.EFCore.Tests.Binders;
 using Microsoft.AspNetCore.OData.Query.Expressions;
 using Xunit;
+using AutoMapper.OData.EFCore.Tests.Model;
 
 namespace AutoMapper.OData.EFCore.Tests
 {

--- a/AutoMapper.OData.EFCore.Tests/Mappings/ObjectMappings.cs
+++ b/AutoMapper.OData.EFCore.Tests/Mappings/ObjectMappings.cs
@@ -25,6 +25,7 @@ namespace AutoMapper.OData.EFCore.Tests.Mappings
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<Product, ProductModel>()
                 .ForAllMembers(o => o.ExplicitExpansion());
+            CreateMap<CompositeKey, CompositeKeyModel>();
         }
     }
 }

--- a/AutoMapper.OData.EFCore.Tests/Model/ModelClasses.cs
+++ b/AutoMapper.OData.EFCore.Tests/Model/ModelClasses.cs
@@ -13,8 +13,8 @@ namespace AutoMapper.OData.EFCore.Tests.Model
     {
         [Key]
         public int ProductID { get; set; }
-
         public string ProductName { get; set; }
+        [Key]
         public int SupplierID { get; set; }
         public int CategoryID { get; set; }
         public string QuantityPerUnit { get; set; }
@@ -62,13 +62,19 @@ namespace AutoMapper.OData.EFCore.Tests.Model
         [Key]
         public int CategoryID { get; set; }
         public string CategoryName { get; set; }
-
         public ProductModel Product { get; set; }
-
         public ICollection<ProductModel> Products { get; set; }
-
+        public ICollection<CompositeKeyModel> CompositeKeys { get; set; }
         public IEnumerable<ProductModel> EnumerableProducts { get; set; }
         public IQueryable<ProductModel> QueryableProducts { get; set; }
+    }
+
+    public class CompositeKeyModel
+    {
+        [Key]
+        public int ID1 { get; set; }
+        [Key]
+        public int ID2 { get; set; }
     }
 
     public class AddressModel


### PR DESCRIPTION
Implements support for `$skip` and `$top` when a order is not explicitly specified which was discussed here #94.

Description:
When either `$skip`, `$top`, or both are specified without an explicit `$orderby` a default order is now created using a suitable property on the model. 