### PR TITLE
Feature/orderby filtered count

### DIFF
--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -221,7 +221,7 @@ namespace AutoMapper.AspNet.OData
                     case CountNode countNode:
                         return expression.GetOrderByCountCall
                         (
-                            countNode.GetPropertyPath(),
+                            countNode,
                             orderByClause.Direction == OrderByDirection.Ascending
                                 ? OrderBy
                                 : OrderByDescending,
@@ -256,7 +256,7 @@ namespace AutoMapper.AspNet.OData
                 {
                     CountNode countNode => expression.GetOrderByCountCall
                     (
-                        countNode.GetPropertyPath(),
+                        countNode,
                         orderByClause.Direction == OrderByDirection.Ascending
                             ? ThenBy
                             : ThenByDescending
@@ -381,11 +381,15 @@ namespace AutoMapper.AspNet.OData
             return Expression.Lambda(delegateType, body, param);//Resulting lambda expression for the selector.
         }
 
-        public static Expression GetOrderByCountCall(this Expression expression, string memberFullName, string methodName, string selectorParameterName = "a")
+        public static Expression GetOrderByCountCall(this Expression expression, CountNode countNode, string methodName, string selectorParameterName = "a")
         {
             Type sourceType = expression.GetUnderlyingElementType();
             ParameterExpression param = Expression.Parameter(sourceType, selectorParameterName);
-            Expression countSelector = param.MakeSelector(memberFullName).GetCountCall();
+            
+            Type filterType = TypeExtensions.GetClrType(countNode.FilterClause.ItemType, TypeExtensions.GetEdmToClrTypeMappings());
+            LambdaExpression filterExpression = countNode.FilterClause.GetFilterExpression(filterType);
+            
+            Expression countSelector = param.MakeSelector(countNode.GetPropertyPath()).GetCountCall(filterExpression);
             return Expression.Call
             (
                 expression.Type.IsIQueryable() ? typeof(Queryable) : typeof(Enumerable),

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -630,6 +630,22 @@ namespace AutoMapper.OData.EFCore.Tests
                 Assert.Equal(2, collection.Last().Buildings.Count);
             }
         }
+        
+        [Fact]
+        public async void OpsTenantOrderByFilteredCount()
+        {
+            Test(Get<OpsTenant, TMandator>("/opstenant?$expand=Buildings&$orderby=Buildings/$count($filter=Name eq 'One L1') desc"));
+            Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$expand=Buildings&$orderby=Buildings/$count($filter=Name eq 'One L1') desc"));
+
+            void Test(ICollection<OpsTenant> collection)
+            {
+                Assert.Equal(2, collection.Count);
+                Assert.NotNull(collection.First().Buildings);
+                Assert.Equal("One", collection.First().Name);
+                Assert.Equal(2, collection.First().Buildings.Count);
+                Assert.Equal(3, collection.Last().Buildings.Count);
+            }
+        }
 
         //ArgumentNullException: Value cannot be null. (Parameter 'bindings')
         //Microsoft.EntityFrameworkCore.InMemory (3.1.0).  Works using Microsoft.EntityFrameworkCore 3.1.

--- a/AutoMapper.OData.EFCore.Tests/GetTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetTests.cs
@@ -500,6 +500,22 @@ namespace AutoMapper.OData.EFCore.Tests
                 Assert.Equal(2, collection.Last().Buildings.Count);
             }
         }
+        
+        [Fact]
+        public async void OpsTenantOrderByFilteredCount()
+        {
+            Test(Get<OpsTenant, TMandator>("/opstenant?$expand=Buildings&$orderby=Buildings/$count($filter=Name eq 'One L1') desc"));
+            Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$expand=Buildings&$orderby=Buildings/$count($filter=Name eq 'One L1') desc"));
+
+            void Test(ICollection<OpsTenant> collection)
+            {
+                Assert.Equal(2, collection.Count);
+                Assert.NotNull(collection.First().Buildings);
+                Assert.Equal("One", collection.First().Name);
+                Assert.Equal(2, collection.First().Buildings.Count);
+                Assert.Equal(3, collection.Last().Buildings.Count);
+            }
+        }
 
         //Exception: 'The Include path 'Mandator->Buildings' results in a cycle.
         //Cycles are not allowed in no-tracking queries. Either use a tracking query or remove the cycle.'


### PR DESCRIPTION
Adding missing feature: order by count with filter:

`$orderBy=collection/$count($filter=property eq 'example') desc`

Added two tests.