### PR TITLE
fix Issue #100 - Expanded navigation properties MUST be returned, even if they are not specified in $select

### DIFF
--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -495,7 +495,7 @@ namespace AutoMapper.AspNet.OData
             if (clause?.SelectExpandClause == null)
                 return new List<List<ODataExpansionOptions>>();
 
-            return clause.SelectExpandClause.SelectedItems.GetExpansions(new HashSet<string>(clause.GetSelects()), parentType);
+            return clause.SelectExpandClause.SelectedItems.GetExpansions(parentType);
         }
 
         private static List<List<ODataExpansionOptions>> GetNestedExpansions(this ExpandedNavigationSelectItem node, Type type)
@@ -503,10 +503,10 @@ namespace AutoMapper.AspNet.OData
             if (node == null)
                 return new List<List<ODataExpansionOptions>>();
 
-            return node.SelectAndExpand.SelectedItems.GetExpansions(new HashSet<string>(node.SelectAndExpand.GetSelects()), type);
+            return node.SelectAndExpand.SelectedItems.GetExpansions(type);
         }
 
-        private static List<List<ODataExpansionOptions>> GetExpansions(this IEnumerable<SelectItem> selectedItems, HashSet<string> selects, Type parentType)
+        private static List<List<ODataExpansionOptions>> GetExpansions(this IEnumerable<SelectItem> selectedItems, Type parentType)
         {
             if (selectedItems == null)
                 return new List<List<ODataExpansionOptions>>();

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -506,14 +506,6 @@ namespace AutoMapper.AspNet.OData
             return node.SelectAndExpand.SelectedItems.GetExpansions(new HashSet<string>(node.SelectAndExpand.GetSelects()), type);
         }
 
-        private static bool ExpansionIsValid(this HashSet<string> siblingSelects, string expansion)
-        {
-            if (!siblingSelects.Any())
-                return true;
-
-            return siblingSelects.Contains(expansion);
-        }
-
         private static List<List<ODataExpansionOptions>> GetExpansions(this IEnumerable<SelectItem> selectedItems, HashSet<string> selects, Type parentType)
         {
             if (selectedItems == null)
@@ -522,9 +514,6 @@ namespace AutoMapper.AspNet.OData
             return selectedItems.OfType<ExpandedNavigationSelectItem>().Aggregate(new List<List<ODataExpansionOptions>>(), (listOfExpansionLists, next) =>
             {
                 string path = next.PathToNavigationProperty.FirstSegment.Identifier;//Only first segment is necessary because of the new syntax $expand=Builder($expand=City) vs $expand=Builder/City
-
-                if (!selects.ExpansionIsValid(path))/*If selects are defined then check to make sure the expansion is one of them.*/
-                    return listOfExpansionLists;
 
                 Type currentParentType = parentType.GetCurrentType();
                 Type memberType = currentParentType.GetMemberInfo(path).GetMemberType();

--- a/AutoMapper.OData.EF6.Tests/GetQuerySelectTests.cs
+++ b/AutoMapper.OData.EF6.Tests/GetQuerySelectTests.cs
@@ -45,7 +45,7 @@ namespace AutoMapper.OData.EF6.Tests
         }
 
         [Fact]
-        public async void OpsTenantSelectName()
+        public async void OpsTenantSelectNameExpandBuildings()
         {
             Test(Get<OpsTenant, TMandator>("/opstenant?$select=Name&$expand=Buildings&$orderby=Name"));
             Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$select=Name&$expand=Buildings&$orderby=Name"));
@@ -53,7 +53,7 @@ namespace AutoMapper.OData.EF6.Tests
             void Test(ICollection<OpsTenant> collection)
             {
                 Assert.Equal(2, collection.Count);
-                Assert.Null(collection.First().Buildings);
+                Assert.Equal(2, collection.First().Buildings.Count);
                 Assert.Equal("One", collection.First().Name);
                 Assert.Equal(default, collection.First().Identity);
             }
@@ -77,7 +77,7 @@ namespace AutoMapper.OData.EF6.Tests
         }
 
         [Fact]
-        public async void BuildingSelectNameExpandBuilder_Builder_ShouldBeNull()
+        public async void BuildingSelectNameExpandBuilder_BuilderNameShouldBeSam()
         {
             Test(Get<CoreBuilding, TBuilding>("/corebuilding?$top=5&$select=Name&$expand=Builder($select=Name)&$filter=Name eq 'One L1'"));
             Test(await GetAsync<CoreBuilding, TBuilding>("/corebuilding?$top=5&$select=Name&$expand=Builder($select=Name)&$filter=Name eq 'One L1'"));
@@ -85,7 +85,9 @@ namespace AutoMapper.OData.EF6.Tests
             void Test(ICollection<CoreBuilding> collection)
             {
                 Assert.Equal(1, collection.Count);
-                Assert.Null(collection.First().Builder);
+                Assert.Equal("Sam", collection.First().Builder.Name);
+                Assert.Equal(default, collection.First().Builder.Id);
+                Assert.Null(collection.First().Builder.City);
                 Assert.Null(collection.First().Tenant);
                 Assert.Equal("One L1", collection.First().Name);
             }
@@ -109,7 +111,7 @@ namespace AutoMapper.OData.EF6.Tests
         }
 
         [Fact]
-        public async void BuildingExpandBuilderSelectNameExpandCityFilterEqAndOrderBy_CityShouldBeNull_BuilderNameShouldeSam_BuilderIdShouldBeZero()
+        public async void BuildingExpandBuilderSelectNameExpandCityFilterEqAndOrderBy_CityShouldBeExpanded_BuilderNameShouldBeSam_BuilderIdShouldBeZero()
         {
             Test(Get<CoreBuilding, TBuilding>("/corebuilding?$top=5&$expand=Builder($select=Name;$expand=City)&$filter=Name eq 'One L1'"));
             Test(await GetAsync<CoreBuilding, TBuilding>("/corebuilding?$top=5&$expand=Builder($select=Name;$expand=City)&$filter=Name eq 'One L1'"));
@@ -119,7 +121,8 @@ namespace AutoMapper.OData.EF6.Tests
                 Assert.Equal(1, collection.Count);
                 Assert.Equal("Sam", collection.First().Builder.Name);
                 Assert.Equal(default, collection.First().Builder.Id);
-                Assert.Null(collection.First().Builder.City);
+                Assert.Equal("London", collection.First().Builder.City.Name);
+                Assert.Equal(1, collection.First().Builder.City.Id);
                 Assert.Equal("One L1", collection.First().Name);
                 Assert.Null(collection.First().Tenant);
             }

--- a/AutoMapper.OData.EF6.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EF6.Tests/GetQueryTests.cs
@@ -188,11 +188,11 @@ namespace AutoMapper.OData.EF6.Tests
             }
         }
 
-        [Fact]//Similar to test below but works if $select=Buildings is added to the query
+        [Fact]
         public async void OpsTenantExpandBuildingsSelectNameAndBuilderExpandBuilderExpandCityFilterNeAndOrderBy()
         {
-            Test(Get<OpsTenant, TMandator>("/opstenant?$top=5&$select=Buildings,Name&$expand=Buildings($select=Name,Builder;$expand=Builder($select=Name,City;$expand=City))&$filter=Name ne 'One'&$orderby=Name desc"));
-            Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$top=5&$select=Buildings,Name&$expand=Buildings($select=Name,Builder;$expand=Builder($select=Name,City;$expand=City))&$filter=Name ne 'One'&$orderby=Name desc"));
+            Test(Get<OpsTenant, TMandator>("/opstenant?$top=5&$select=Name&$expand=Buildings($select=Name,Builder;$expand=Builder($select=Name,City;$expand=City))&$filter=Name ne 'One'&$orderby=Name desc"));
+            Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$top=5&$select=Name&$expand=Buildings($select=Name,Builder;$expand=Builder($select=Name,City;$expand=City))&$filter=Name ne 'One'&$orderby=Name desc"));
 
             void Test(ICollection<OpsTenant> collection)
             {

--- a/AutoMapper.OData.EFCore.Tests/GetQuerySelectTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQuerySelectTests.cs
@@ -58,7 +58,7 @@ namespace AutoMapper.OData.EFCore.Tests
         }
 
         [Fact]
-        public async void OpsTenantSelectName()
+        public async void OpsTenantSelectNameExpandBuildings()
         {
             Test(Get<OpsTenant, TMandator>("/opstenant?$select=Name&$expand=Buildings&$orderby=Name"));
             Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$select=Name&$expand=Buildings&$orderby=Name"));
@@ -66,7 +66,7 @@ namespace AutoMapper.OData.EFCore.Tests
             void Test(ICollection<OpsTenant> collection)
             {
                 Assert.Equal(2, collection.Count);
-                Assert.Null(collection.First().Buildings);
+                Assert.Equal(2, collection.First().Buildings.Count);
                 Assert.Equal("One", collection.First().Name);
                 Assert.Equal(default, collection.First().Identity);
             }
@@ -90,7 +90,7 @@ namespace AutoMapper.OData.EFCore.Tests
         }
 
         [Fact]
-        public async void BuildingSelectNameExpandBuilder_Builder_ShouldBeNull()
+        public async void BuildingSelectNameExpandBuilder_BuilderNameShouldBeSam()
         {
             Test(Get<CoreBuilding, TBuilding>("/corebuilding?$top=5&$select=Name&$expand=Builder($select=Name)&$filter=Name eq 'One L1'"));
             Test(await GetAsync<CoreBuilding, TBuilding>("/corebuilding?$top=5&$select=Name&$expand=Builder($select=Name)&$filter=Name eq 'One L1'"));
@@ -98,7 +98,9 @@ namespace AutoMapper.OData.EFCore.Tests
             void Test(ICollection<CoreBuilding> collection)
             {
                 Assert.Equal(1, collection.Count);
-                Assert.Null(collection.First().Builder);
+                Assert.Equal("Sam", collection.First().Builder.Name);
+                Assert.Equal(default, collection.First().Builder.Id);
+                Assert.Null(collection.First().Builder.City);
                 Assert.Null(collection.First().Tenant);
                 Assert.Equal("One L1", collection.First().Name);
             }
@@ -122,7 +124,7 @@ namespace AutoMapper.OData.EFCore.Tests
         }
 
         [Fact]
-        public async void BuildingExpandBuilderSelectNameExpandCityFilterEqAndOrderBy_CityShouldBeNull_BuilderNameShouldeSam_BuilderIdShouldBeZero()
+        public async void BuildingExpandBuilderSelectNameExpandCityFilterEqAndOrderBy_CityShouldBeExpanded_BuilderNameShouldBeSam_BuilderIdShouldBeZero()
         {
             Test(Get<CoreBuilding, TBuilding>("/corebuilding?$top=5&$expand=Builder($select=Name;$expand=City)&$filter=Name eq 'One L1'"));
             Test(await GetAsync<CoreBuilding, TBuilding>("/corebuilding?$top=5&$expand=Builder($select=Name;$expand=City)&$filter=Name eq 'One L1'"));
@@ -132,7 +134,8 @@ namespace AutoMapper.OData.EFCore.Tests
                 Assert.Equal(1, collection.Count);
                 Assert.Equal("Sam", collection.First().Builder.Name);
                 Assert.Equal(default, collection.First().Builder.Id);
-                Assert.Null(collection.First().Builder.City);
+                Assert.Equal("London", collection.First().Builder.City.Name);
+                Assert.Equal(1, collection.First().Builder.City.Id);
                 Assert.Equal("One L1", collection.First().Name);
                 Assert.Null(collection.First().Tenant);
             }

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -253,11 +253,11 @@ namespace AutoMapper.OData.EFCore.Tests
             }
         }
 
-        [Fact]//Similar to test below but works if $select=Buildings is added to the query
+        [Fact]
         public async void OpsTenantExpandBuildingsSelectNameAndBuilderExpandBuilderExpandCityFilterNeAndOrderBy()
         {
-            Test(Get<OpsTenant, TMandator>("/opstenant?$top=5&$select=Buildings,Name&$expand=Buildings($select=Name,Builder;$expand=Builder($select=Name,City;$expand=City))&$filter=Name ne 'One'&$orderby=Name desc"));
-            Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$top=5&$select=Buildings,Name&$expand=Buildings($select=Name,Builder;$expand=Builder($select=Name,City;$expand=City))&$filter=Name ne 'One'&$orderby=Name desc"));
+            Test(Get<OpsTenant, TMandator>("/opstenant?$top=5&$select=Name&$expand=Buildings($select=Name,Builder;$expand=Builder($select=Name,City;$expand=City))&$filter=Name ne 'One'&$orderby=Name desc"));
+            Test(await GetAsync<OpsTenant, TMandator>("/opstenant?$top=5&$select=Name&$expand=Buildings($select=Name,Builder;$expand=Builder($select=Name,City;$expand=City))&$filter=Name ne 'One'&$orderby=Name desc"));
 
             void Test(ICollection<OpsTenant> collection)
             {


### PR DESCRIPTION
This fixes issue #100.