### PR TITLE
A few tests with custom projection parameters

### DIFF
--- a/AutoMapper.OData.EFCore.Tests/Mappings/ObjectMappings.cs
+++ b/AutoMapper.OData.EFCore.Tests/Mappings/ObjectMappings.cs
@@ -11,9 +11,17 @@ namespace AutoMapper.OData.EFCore.Tests.Mappings
     {
         public ObjectMappings()
         {
+            int? currentUserFavoriteCategory = null;
+            string currentUserState = null;
+
             CreateMap<Address, AddressModel>()
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<Category, CategoryModel>()
+                .ForMember(
+                    categoryModel => categoryModel.IsFavorite,
+                    o => o.MapFrom(
+                        category => currentUserFavoriteCategory.HasValue
+                                    && category.CategoryID == currentUserFavoriteCategory.Value))
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<DataTypes, DataTypesModel>()
                 .ForAllMembers(o => o.ExplicitExpansion());
@@ -24,6 +32,11 @@ namespace AutoMapper.OData.EFCore.Tests.Mappings
             CreateMap<DynamicProduct, DynamicProductModel>()
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<Product, ProductModel>()
+                .ForMember(
+                    productModel => productModel.IsShippableToUser,
+                    o => o.MapFrom(
+                        product => !string.IsNullOrEmpty(currentUserState)
+                                   && product.SupplierAddress.State == currentUserState))
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<CompositeKey, CompositeKeyModel>();
         }

--- a/AutoMapper.OData.EFCore.Tests/Mappings/ObjectMappings.cs
+++ b/AutoMapper.OData.EFCore.Tests/Mappings/ObjectMappings.cs
@@ -26,10 +26,25 @@ namespace AutoMapper.OData.EFCore.Tests.Mappings
             CreateMap<DataTypes, DataTypesModel>()
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<DerivedCategory, DerivedCategoryModel>()
+                .ForMember(
+                    categoryModel => categoryModel.IsFavorite,
+                    o => o.MapFrom(
+                        category => currentUserFavoriteCategory.HasValue
+                                    && category.CategoryID == currentUserFavoriteCategory.Value))
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<DerivedProduct, DerivedProductModel>()
+                .ForMember(
+                    productModel => productModel.IsShippableToUser,
+                    o => o.MapFrom(
+                        product => !string.IsNullOrEmpty(currentUserState)
+                                   && product.SupplierAddress.State == currentUserState))
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<DynamicProduct, DynamicProductModel>()
+                .ForMember(
+                    productModel => productModel.IsShippableToUser,
+                    o => o.MapFrom(
+                        product => !string.IsNullOrEmpty(currentUserState)
+                                   && product.SupplierAddress.State == currentUserState))
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<Product, ProductModel>()
                 .ForMember(

--- a/AutoMapper.OData.EFCore.Tests/Model/ModelClasses.cs
+++ b/AutoMapper.OData.EFCore.Tests/Model/ModelClasses.cs
@@ -48,9 +48,12 @@ namespace AutoMapper.OData.EFCore.Tests.Model
 
         public SimpleEnumModel Ranking { get; set; }
 
+
         public CategoryModel Category { get; set; }
 
         public AddressModel SupplierAddress { get; set; }
+
+        public bool IsShippableToUser { get; set; }
 
         public int[] AlternateIDs { get; set; }
         public AddressModel[] AlternateAddresses { get; set; }
@@ -62,6 +65,7 @@ namespace AutoMapper.OData.EFCore.Tests.Model
         [Key]
         public int CategoryID { get; set; }
         public string CategoryName { get; set; }
+        public bool IsFavorite { get; set; }
         public ProductModel Product { get; set; }
         public ICollection<ProductModel> Products { get; set; }
         public ICollection<CompositeKeyModel> CompositeKeys { get; set; }


### PR DESCRIPTION
Here are the unit tests demonstrating the issues regarding custom projection parameters.

Some tests work in an in-memory scenario (like `FilteringOnChildCollection_ParameterizedProjectedProperty_WithMatches`) but an additional check in an EF / EF Core environment would be safer.