### PR TITLE
Implement count in expansion options

### DIFF
--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -560,14 +560,14 @@ namespace AutoMapper.AspNet.OData
 
                 QueryOptions GetQuery()
                     => HasQuery()
-                        ? new QueryOptions(next.OrderByOption, (int?)next.SkipOption, (int?)next.TopOption)
+                        ? new QueryOptions(next.OrderByOption, (int?)next.SkipOption, (int?)next.TopOption, next.CountOption)
                         : null;
 
                 bool HasFilter()
                     => memberType.IsList() && next.FilterOption != null;
 
                 bool HasQuery()
-                    => memberType.IsList() && (next.OrderByOption != null || next.SkipOption.HasValue || next.TopOption.HasValue);
+                    => memberType.IsList() && (next.OrderByOption != null || next.SkipOption.HasValue || next.TopOption.HasValue || next.CountOption.HasValue);
             });
         }
 
@@ -731,7 +731,7 @@ namespace AutoMapper.AspNet.OData
                                     MemberName = next.MemberName,
                                     MemberType = next.MemberType,
                                     ParentType = next.ParentType,
-                                    QueryOptions = new QueryOptions(next.QueryOptions.OrderByClause, next.QueryOptions.Skip, next.QueryOptions.Top)
+                                    QueryOptions = new QueryOptions(next.QueryOptions.OrderByClause, next.QueryOptions.Skip, next.QueryOptions.Top, next.QueryOptions.Count)
                                 }
                             );//add expansion with query options
 
@@ -759,13 +759,15 @@ namespace AutoMapper.AspNet.OData
 
     public class QueryOptions
     {
-        public QueryOptions(OrderByClause orderByClause, int? skip, int? top)
+        public QueryOptions(OrderByClause orderByClause, int? skip, int? top, bool? count)
         {
             OrderByClause = orderByClause;
             Skip = skip;
             Top = top;
+            Count = count;
         }
 
+        public bool? Count { get; set; }
         public OrderByClause OrderByClause { get; set; }
         public int? Skip { get; set; }
         public int? Top { get; set; }

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -964,6 +964,26 @@ namespace AutoMapper.OData.EFCore.Tests
         }
 
         [Fact]
+        public async void CountingOnChildCollection()
+        {
+            string query = "/CategoryModel?$expand=Products($count=true)";
+            Test
+            (
+                Get<CategoryModel, Category>
+                (
+                    query,
+                    GetCategories()
+                )
+            );
+            
+            static void Test(ICollection<CategoryModel> collection)
+            {
+                Assert.Single(collection);
+                Assert.Single(collection.First().Products);
+            }
+        }
+
+        [Fact]
         public async void FilteringOnRoot_AndChildCollection_WithNoMatches()
         {
             string query = "/CategoryModel?$top=5&$expand=Products($filter=ProductName ne '';$orderby=ProductName desc)&$filter=CategoryName ne ''&$orderby=CategoryName asc";


### PR DESCRIPTION
Addresses #137

Note: First time touching the code of this repo. I don't see any contribution docs, so I'm not sure what is necessary.

I think the test I wrote is pretty useless, but I don't see a way to verify if `[ObjectType]@odata.count` is in the response.