### PR TITLE
Add support for EnableConstantParameterization

### DIFF
--- a/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EF6/QueryableExtensions.cs
@@ -26,7 +26,11 @@ namespace AutoMapper.AspNet.OData
         public static ICollection<TModel> Get<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.Default);
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>
+            (
+                querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.Default,
+                enableConstantParameterization: querySettings?.ODataSettings?.EnableConstantParameterization ?? true
+            );
             query.ApplyOptions(mapper, filter, options, querySettings);
             return query.Get
             (
@@ -50,7 +54,11 @@ namespace AutoMapper.AspNet.OData
         public static async Task<ICollection<TModel>> GetAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.Default);
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>
+            (
+                querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.Default, 
+                enableConstantParameterization: querySettings?.ODataSettings?.EnableConstantParameterization ?? true
+            );
             await query.ApplyOptionsAsync(mapper, filter, options, querySettings);
             return await query.GetAsync
             (
@@ -75,7 +83,11 @@ namespace AutoMapper.AspNet.OData
         public static async Task<IQueryable<TModel>> GetQueryAsync<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False);
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>
+            (
+                querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False, 
+                enableConstantParameterization: querySettings?.ODataSettings?.EnableConstantParameterization ?? true
+            );
             await query.ApplyOptionsAsync(mapper, filter, options, querySettings);
             return query.GetQueryable(mapper, options, querySettings, filter);
         }
@@ -93,7 +105,11 @@ namespace AutoMapper.AspNet.OData
         public static IQueryable<TModel> GetQuery<TModel, TData>(this IQueryable<TData> query, IMapper mapper, ODataQueryOptions<TModel> options, QuerySettings querySettings = null)
             where TModel : class
         {
-            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False);
+            Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>
+            (
+                querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
+                enableConstantParameterization: querySettings?.ODataSettings?.EnableConstantParameterization ?? true
+            );
             query.ApplyOptions(mapper, filter, options, querySettings);
             return query.GetQueryable(mapper, options, querySettings, filter);
         }

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -33,14 +33,20 @@ namespace AutoMapper.AspNet.OData
         /// <typeparam name="T"></typeparam>
         /// <param name="filterOption"></param>
         /// <returns></returns>
-        public static Expression<Func<T, bool>> ToFilterExpression<T>(this FilterQueryOption filterOption, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default, TimeZoneInfo timeZone = null)
+        public static Expression<Func<T, bool>> ToFilterExpression<T>(
+            this FilterQueryOption filterOption,
+            HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default,
+            TimeZoneInfo timeZone = null,
+            bool enableConstantParameterization = true)
         {
             if (filterOption == null)
                 return null;
 
             IQueryable queryable = Enumerable.Empty<T>().AsQueryable();
 
-            queryable = filterOption.ApplyTo(queryable, new ODataQuerySettings() { HandleNullPropagation = handleNullPropagation, TimeZone = timeZone });
+            queryable = filterOption.ApplyTo(
+                queryable,
+                new ODataQuerySettings() { HandleNullPropagation = handleNullPropagation, TimeZone = timeZone, EnableConstantParameterization = enableConstantParameterization });
 
             MethodCallExpression whereMethodCallExpression = (MethodCallExpression)queryable.Expression;
 
@@ -53,13 +59,19 @@ namespace AutoMapper.AspNet.OData
         /// <typeparam name="T"></typeparam>
         /// <param name="filterOption"></param>
         /// <returns></returns>
-        public static Expression<Func<T, bool>> ToSearchExpression<T>(this SearchQueryOption filterOption, HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default, TimeZoneInfo timeZone = null)
+        public static Expression<Func<T, bool>> ToSearchExpression<T>(
+            this SearchQueryOption filterOption,            
+            HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default,
+            TimeZoneInfo timeZone = null,
+            bool enableConstantParameterization = true)
         {
             if (filterOption == null)
                 return null;
 
             IQueryable queryable = Enumerable.Empty<T>().AsQueryable();
-            queryable = filterOption.ApplyTo(queryable, new ODataQuerySettings() { HandleNullPropagation = handleNullPropagation, TimeZone = timeZone });
+            queryable = filterOption.ApplyTo(
+                queryable,
+                new ODataQuerySettings() { HandleNullPropagation = handleNullPropagation, TimeZone = timeZone, EnableConstantParameterization = enableConstantParameterization });
 
             MethodCallExpression whereMethodCallExpression = (MethodCallExpression)queryable.Expression;
 
@@ -68,7 +80,8 @@ namespace AutoMapper.AspNet.OData
 
         public static Expression<Func<T, bool>> ToFilterExpression<T>(this ODataQueryOptions<T> options,
             HandleNullPropagationOption handleNullPropagation = HandleNullPropagationOption.Default,
-            TimeZoneInfo timeZone = null)
+            TimeZoneInfo timeZone = null,
+            bool enableConstantParameterization = true)
         {
             if (options is null || options.Filter is null && options.Search is null)
             {
@@ -80,14 +93,14 @@ namespace AutoMapper.AspNet.OData
             Expression filterExpression = null;
             if (options.Filter is not null)
             {
-                var raw = options.Filter.ToFilterExpression<T>(handleNullPropagation, timeZone);
+                var raw = options.Filter.ToFilterExpression<T>(handleNullPropagation, timeZone, enableConstantParameterization);
                 filterExpression = raw.Body.ReplaceParameter(raw.Parameters[0], parameter);
             }
 
             Expression searchExpression = null;
             if (options.Search is not null)
             {
-                var raw = options.Search.ToSearchExpression<T>(handleNullPropagation, timeZone);
+                var raw = options.Search.ToSearchExpression<T>(handleNullPropagation, timeZone, enableConstantParameterization);
                 searchExpression = raw.Body.ReplaceParameter(raw.Parameters[0], parameter);
             }
 

--- a/AutoMapper.AspNetCore.OData.EFCore/ODataSettings.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/ODataSettings.cs
@@ -33,5 +33,13 @@ namespace AutoMapper.AspNet.OData
         /// Default is null.
         /// </value>
         public TimeZoneInfo TimeZone { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether constants should be parameterized.
+        /// </summary>
+        /// <value>
+        /// Default is true.
+        /// </value>
+        public bool EnableConstantParameterization { get; set; } = true;
     }
 }

--- a/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/QueryableExtensions.cs
@@ -19,7 +19,8 @@ namespace AutoMapper.AspNet.OData
         {
             Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(
                 querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
-                querySettings?.ODataSettings?.TimeZone);
+                querySettings?.ODataSettings?.TimeZone,
+                querySettings?.ODataSettings?.EnableConstantParameterization ?? true);
 
             query.ApplyOptions(mapper, filter, options, querySettings);
             return query.Get
@@ -36,7 +37,8 @@ namespace AutoMapper.AspNet.OData
         {            
             Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(
                 querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
-                querySettings?.ODataSettings?.TimeZone);
+                querySettings?.ODataSettings?.TimeZone,
+                querySettings?.ODataSettings?.EnableConstantParameterization ?? true);
             await query.ApplyOptionsAsync(mapper, filter, options, querySettings);
             return await query.GetAsync
             (
@@ -52,8 +54,9 @@ namespace AutoMapper.AspNet.OData
             where TModel : class
         {
             Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(
-                     querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
-                     querySettings?.ODataSettings?.TimeZone);
+                querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
+                querySettings?.ODataSettings?.TimeZone,
+                querySettings?.ODataSettings?.EnableConstantParameterization ?? true);
                 
             await query.ApplyOptionsAsync(mapper, filter, options, querySettings);
             return query.GetQueryable(mapper, options, querySettings, filter);
@@ -64,7 +67,8 @@ namespace AutoMapper.AspNet.OData
         {
             Expression<Func<TModel, bool>> filter = options.ToFilterExpression<TModel>(
                 querySettings?.ODataSettings?.HandleNullPropagation ?? HandleNullPropagationOption.False,
-                querySettings?.ODataSettings?.TimeZone);
+                querySettings?.ODataSettings?.TimeZone,
+                querySettings?.ODataSettings?.EnableConstantParameterization ?? true);
             query.ApplyOptions(mapper, filter, options, querySettings);
             return query.GetQueryable(mapper, options, querySettings, filter);
         }

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -218,37 +218,7 @@ namespace AutoMapper.OData.EFCore.Tests
                 Assert.Null(collection.First().Buildings);
                 Assert.Equal("One", collection.First().Name);
             }
-        }
-
-        [Fact]
-        public void BuildingsFilterNameDisableConstantParameterization()
-        {
-            string query = "/corebuilding?$filter=contains(Name, 'Two L2')";
-            Test(GetQuery<CoreBuilding, TBuilding>(query, querySettings: new() { ODataSettings = new() { EnableConstantParameterization = false } }));
-
-            void Test(IQueryable<CoreBuilding> queryable)
-            {
-                string sqlQuery = queryable.ToQueryString();
-                Assert.Contains("LIKE N'%Two L2%'", sqlQuery);           
-                Assert.DoesNotContain("DECLARE", sqlQuery);
-                Assert.DoesNotContain("ESCAPE", sqlQuery);
-            }
-        }
-
-        [Fact]
-        public void BuildingsFilterNameEnableConstantParameterization()
-        {
-            string query = "/corebuilding?$filter=contains(Name, 'Two L2')";
-            Test(GetQuery<CoreBuilding, TBuilding>(query, querySettings: new() { ODataSettings = new() { EnableConstantParameterization = true } }));
-
-            void Test(IQueryable<CoreBuilding> queryable)
-            {
-                string sqlQuery = queryable.ToQueryString();
-                Assert.DoesNotContain("LIKE N'%Two L2%'", sqlQuery);
-                Assert.Contains("DECLARE", sqlQuery);
-                Assert.Contains("ESCAPE", sqlQuery);
-            }
-        }
+        }        
 
         [Fact]
         public async void OpsTenantFilterLtDateNoExpand()
@@ -766,6 +736,36 @@ namespace AutoMapper.OData.EFCore.Tests
             {
                 Assert.Equal(3, collection.Count);
                 Assert.Null(options.Request.ODataFeature().NextLink);
+            }
+        }
+
+        [Fact]
+        public void BuildingsFilterNameDisableConstantParameterization()
+        {
+            string query = "/corebuilding?$filter=contains(Name, 'Two L2')";
+            Test(GetQuery<CoreBuilding, TBuilding>(query, querySettings: new() { ODataSettings = new() { EnableConstantParameterization = false } }));
+
+            void Test(IQueryable<CoreBuilding> queryable)
+            {
+                string sqlQuery = queryable.ToQueryString();
+                Assert.Contains("LIKE N'%Two L2%'", sqlQuery);
+                Assert.DoesNotContain("DECLARE", sqlQuery);
+                Assert.DoesNotContain("ESCAPE", sqlQuery);
+            }
+        }
+
+        [Fact]
+        public void BuildingsFilterNameEnableConstantParameterization()
+        {
+            string query = "/corebuilding?$filter=contains(Name, 'Two L2')";
+            Test(GetQuery<CoreBuilding, TBuilding>(query, querySettings: new() { ODataSettings = new() { EnableConstantParameterization = true } }));
+
+            void Test(IQueryable<CoreBuilding> queryable)
+            {
+                string sqlQuery = queryable.ToQueryString();
+                Assert.DoesNotContain("LIKE N'%Two L2%'", sqlQuery);
+                Assert.Contains("DECLARE", sqlQuery);
+                Assert.Contains("ESCAPE", sqlQuery);
             }
         }
 

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -218,7 +218,7 @@ namespace AutoMapper.OData.EFCore.Tests
                 Assert.Null(collection.First().Buildings);
                 Assert.Equal("One", collection.First().Name);
             }
-        }        
+        }
 
         [Fact]
         public async void OpsTenantFilterLtDateNoExpand()
@@ -1339,7 +1339,7 @@ namespace AutoMapper.OData.EFCore.Tests
         {
             var cancelledToken = new CancellationTokenSource(TimeSpan.Zero).Token;
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => GetAsync<CoreBuilding, TBuilding>("/corebuilding?$count=true", querySettings: new QuerySettings { AsyncSettings = new AsyncSettings { CancellationToken = cancelledToken } }));
-        }        
+        }
 
         private ICollection<TModel> Get<TModel, TData>(string query, IQueryable<TData> dataQueryable, ODataQueryOptions<TModel> options = null, QuerySettings querySettings = null) where TModel : class where TData : class
         {

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -229,7 +229,7 @@ namespace AutoMapper.OData.EFCore.Tests
             void Test(IQueryable<CoreBuilding> queryable)
             {
                 string sqlQuery = queryable.ToQueryString();
-                Assert.Contains("LIKE N'%Two L2%'", queryable.ToQueryString());           
+                Assert.Contains("LIKE N'%Two L2%'", sqlQuery);           
                 Assert.DoesNotContain("DECLARE", sqlQuery);
                 Assert.DoesNotContain("ESCAPE", sqlQuery);
             }


### PR DESCRIPTION
adds the possibility of configuring the EnableConstantParameterization of ODataQuerySettings object. It is useful to be able to configure that property, since it can affect performance drastically. 

Related discussion: https://github.com/AutoMapper/AutoMapper.Extensions.OData/discussions/212
Related documentation: https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnet.odata.query.odataquerysettings.enableconstantparameterization?view=odata-aspnetcore-7.0