### PR TITLE
Fix expand with nested filer on model without default constructor

### DIFF
--- a/AutoMapper.AspNetCore.OData.EFCore/Visitors/ProjectionVisitor.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Visitors/ProjectionVisitor.cs
@@ -26,7 +26,7 @@ namespace AutoMapper.AspNet.OData.Visitors
 
             return Expression.MemberInit
             (
-                Expression.New(node.Type),
+                Expression.New(node.NewExpression.Constructor, node.NewExpression.Arguments),
                 node.Bindings.OfType<MemberAssignment>().Aggregate
                 (
                     new List<MemberBinding>(),

--- a/AutoMapper.OData.EFCore.Tests/Data/DataClasses.cs
+++ b/AutoMapper.OData.EFCore.Tests/Data/DataClasses.cs
@@ -69,6 +69,19 @@ namespace AutoMapper.OData.EFCore.Tests.Data
         public IQueryable<Product> QueryableProducts { get; set; }
     }
 
+    public class SuperCategory
+    {
+        public SuperCategory(string superCategoryName)
+        {
+            SuperCategoryName = superCategoryName;
+        }
+
+        public int SuperCategoryID { get; set; }
+        public string SuperCategoryName { get; set; }
+
+        public IEnumerable<Category> Categories { get; set; }
+    }
+
     public class CompositeKey
     {        
         public int ID1 { get; set; }        

--- a/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetQueryTests.cs
@@ -1334,6 +1334,51 @@ namespace AutoMapper.OData.EFCore.Tests
             }
         }
 
+        private IQueryable<SuperCategory> GetSuperCategories()
+         => new SuperCategory[]
+            {
+                new SuperCategory("SuperCategoryOne")
+                {
+                    SuperCategoryID = 1,
+                    Categories = GetCategories()
+                },
+                new SuperCategory("SuperCategoryTwo")
+                {
+                    SuperCategoryID = 2,
+                    Categories = Enumerable.Empty<Category>()
+                }
+            }.AsQueryable();
+
+        [Fact]
+        public async void ExpandChildCollectionWithNoDefaultConstructorNoFilter()
+        {
+            const string query = "/SuperCategoryModel?$expand=Categories";
+            Test(await GetAsync<SuperCategoryModel, SuperCategory>(query, GetSuperCategories()));
+            Test(await GetUsingCustomNameSpace<SuperCategoryModel, SuperCategory>(query, GetSuperCategories()));
+            Test(Get<SuperCategoryModel, SuperCategory>(query, GetSuperCategories()));
+
+            static void Test(ICollection<SuperCategoryModel> collection)
+            {
+                Assert.NotEmpty(collection.First().Categories);
+                Assert.Empty(collection.Last().Categories);
+            }
+        }
+
+        [Fact]
+        public async void ExpandChildCollectionWithNoDefaultConstructorNestedFilter()
+        {
+            const string query = "/SuperCategoryModel?$expand=Categories($filter=CategoryName eq 'CategoryOne')";
+            Test(await GetAsync<SuperCategoryModel, SuperCategory>(query, GetSuperCategories()));
+            Test(await GetUsingCustomNameSpace<SuperCategoryModel, SuperCategory>(query, GetSuperCategories()));
+            Test(Get<SuperCategoryModel, SuperCategory>(query, GetSuperCategories()));
+
+            static void Test(ICollection<SuperCategoryModel> collection)
+            {
+                Assert.Single(collection.First().Categories);
+                Assert.Empty(collection.Last().Categories);
+            }
+        }
+
         [Fact]
         public async Task CancellationThrowsException()
         {

--- a/AutoMapper.OData.EFCore.Tests/Mappings/ObjectMappings.cs
+++ b/AutoMapper.OData.EFCore.Tests/Mappings/ObjectMappings.cs
@@ -15,6 +15,8 @@ namespace AutoMapper.OData.EFCore.Tests.Mappings
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<Category, CategoryModel>()
                 .ForAllMembers(o => o.ExplicitExpansion());
+            CreateMap<SuperCategory, SuperCategoryModel>()
+                .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<DataTypes, DataTypesModel>()
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<DerivedCategory, DerivedCategoryModel>()

--- a/AutoMapper.OData.EFCore.Tests/Model/ModelClasses.cs
+++ b/AutoMapper.OData.EFCore.Tests/Model/ModelClasses.cs
@@ -69,6 +69,19 @@ namespace AutoMapper.OData.EFCore.Tests.Model
         public IQueryable<ProductModel> QueryableProducts { get; set; }
     }
 
+    public class SuperCategoryModel
+    {
+        public SuperCategoryModel(string superCategoryName)
+        {
+            SuperCategoryName = superCategoryName;
+        }
+
+        [Key]
+        public int SuperCategoryID { get; set; }
+        public string SuperCategoryName { get; set; }
+        public IEnumerable<CategoryModel> Categories { get; set; }
+    }
+
     public class CompositeKeyModel
     {
         [Key]


### PR DESCRIPTION
When using an expand query with nested filter in combination with a model without a default constructor, it's currently throwing an ArgumentException. This PR updates the ProjectVisitor to also handle models without default constructor and is passing the arguments.