### PR TITLE
Fix stack overflow when EnableLowerCamelCase is used (fixes #233)

### DIFF
--- a/AutoMapper.OData.EF6.Tests/GetTests.cs
+++ b/AutoMapper.OData.EF6.Tests/GetTests.cs
@@ -645,6 +645,8 @@ namespace AutoMapper.OData.EF6.Tests
             if (customNamespace != null)
                 builder.Namespace = customNamespace;
 
+            builder.EnableLowerCamelCase();
+
             builder.EntitySet<T>(typeof(T).Name);
             IEdmModel model = builder.GetEdmModel();
             IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet(typeof(T).Name);

--- a/AutoMapper.OData.EFCore.Tests/GetTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/GetTests.cs
@@ -686,6 +686,8 @@ namespace AutoMapper.OData.EFCore.Tests
             if (customNamespace != null)
                 builder.Namespace = customNamespace;
 
+            builder.EnableLowerCamelCase();
+
             builder.EntitySet<T>(typeof(T).Name);
             IEdmModel model = builder.GetEdmModel();
             IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet(typeof(T).Name);
@@ -705,6 +707,8 @@ namespace AutoMapper.OData.EFCore.Tests
             ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
             if (customNamespace != null)
                 builder.Namespace = customNamespace;
+
+            builder.EnableLowerCamelCase();
 
             builder.EntitySet<X.CategoryModel>(typeof(X.CategoryModel).Name + "X");
             builder.EntitySet<Model.CategoryModel>(nameof(Model.CategoryModel));

--- a/ExpressionBuilder.Tests/ODataHelpers.cs
+++ b/ExpressionBuilder.Tests/ODataHelpers.cs
@@ -25,6 +25,7 @@ namespace ExpressionBuilder.Tests
 
             IEdmModel GetModel(ODataConventionModelBuilder builder)
             {
+                builder.EnableLowerCamelCase();
                 builder.EntitySet<T>(modelType.Name);
                 if (modelType == typeof(Product))
                 {
@@ -51,6 +52,7 @@ namespace ExpressionBuilder.Tests
                 entitySet,
                 queryOptions
             );
+            parser.Resolver = new ODataUriResolver { EnableCaseInsensitive = true };
 
             return parser.ParseSelectAndExpand();
         }
@@ -75,6 +77,7 @@ namespace ExpressionBuilder.Tests
                 entitySet,
                 queryOptions
             );
+            parser.Resolver = new ODataUriResolver { EnableCaseInsensitive = true };
 
             if (useFilterOption)
             {
@@ -108,6 +111,7 @@ namespace ExpressionBuilder.Tests
         public static ODataQueryOptions<T> GetODataQueryOptions<T>(string queryString, IServiceProvider serviceProvider, IRouteBuilder routeBuilder) where T : class
         {
             ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EnableLowerCamelCase();
 
             builder.EntitySet<T>(typeof(T).Name);
             IEdmModel model = builder.GetEdmModel();

--- a/WebAPI.OData.EF6/Startup.cs
+++ b/WebAPI.OData.EF6/Startup.cs
@@ -71,6 +71,7 @@ namespace WebAPI.OData.EF6
         {
             var builder = new ODataConventionModelBuilder();
             //builder.Namespace = "com.FooBar";
+            builder.EnableLowerCamelCase();
             builder.EntitySet<OpsTenant>(nameof(OpsTenant));
             builder.EntitySet<CoreBuilding>(nameof(CoreBuilding));
             builder.EntitySet<OpsBuilder>(nameof(OpsBuilder));

--- a/WebAPI.OData.EFCore/Startup.cs
+++ b/WebAPI.OData.EFCore/Startup.cs
@@ -66,6 +66,7 @@ namespace WebAPI.OData.EFCore
         private IEdmModel GetEdmModel()
         {
             var builder = new ODataConventionModelBuilder();
+            builder.EnableLowerCamelCase();
             //builder.Namespace = "com.FooBar";
             builder.EntitySet<OpsTenant>(nameof(OpsTenant));
             builder.EntitySet<CoreBuilding>(nameof(CoreBuilding));


### PR DESCRIPTION
This fixes bug #233, which affects apps that use EnableLowerCamelCase.  This regression was introduced in #229, due to the public EDM model using lowercase property names whereas the C# classes use capitalized names.  

This fix works by looking up each navigation property's corresponding C# property name.  This might not work if the EDM model was built by hand, meaning it omits annotations.  If any app still has the stack overflow, we could try changing the ToHashSet calls to use `StringComparer.OrdinalIgnoreCase` as a fallback.

This pull request also changes all of the tests to use `EnableLowerCamelCase`, though ideally we'd test both with and without this mode.