### PR TITLE
Default expansion of dictionaries supported

### DIFF
--- a/AutoMapper.AspNetCore.OData.EFCore/Expansions/DefaultExpansionsBuilder.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Expansions/DefaultExpansionsBuilder.cs
@@ -50,24 +50,17 @@ namespace AutoMapper.AspNet.OData.Expansions
 
                 if (LogicBuilder.Expressions.Utils.TypeExtensions.IsLiteralType(memberType))
                     continue;
-
-                if (memberType.IsGenericType)
-                {
-                    Type genericTypeDef = memberType.GetGenericTypeDefinition();
-                    if (genericTypeDef == typeof(IDictionary<,>) || genericTypeDef == typeof(Dictionary<,>))
-                        continue;
-                }                
-
+                
                 if (LogicBuilder.Expressions.Utils.TypeExtensions.IsList(memberType)
                     && LogicBuilder.Expressions.Utils.TypeExtensions.IsLiteralType
                         (
-                            LogicBuilder.Expressions.Utils.TypeExtensions.GetUnderlyingElementType(memberType)
+                            TypeExtensions.GetUnderlyingElementType(memberType)
                         ) == false)
                 {
                     List<LambdaExpression> childMemberSelectors = [];
                     ParameterExpression childParam = Expression.Parameter
                     (
-                         LogicBuilder.Expressions.Utils.TypeExtensions.GetUnderlyingElementType(memberType),
+                         TypeExtensions.GetUnderlyingElementType(memberType),
                          GetChildParameterName(param.Name)
                     );
 
@@ -83,7 +76,7 @@ namespace AutoMapper.AspNet.OData.Expansions
                                 (
                                     typeof(Enumerable),
                                     "Select",
-                                    [LogicBuilder.Expressions.Utils.TypeExtensions.GetUnderlyingElementType(selector), typeof(object)],
+                                    [TypeExtensions.GetUnderlyingElementType(selector), typeof(object)],
                                     selector,
                                     childSelector
                                 ),

--- a/AutoMapper.AspNetCore.OData.EFCore/Expansions/DefaultExpansionsBuilder.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/Expansions/DefaultExpansionsBuilder.cs
@@ -51,6 +51,13 @@ namespace AutoMapper.AspNet.OData.Expansions
                 if (LogicBuilder.Expressions.Utils.TypeExtensions.IsLiteralType(memberType))
                     continue;
 
+                if (memberType.IsGenericType)
+                {
+                    Type genericTypeDef = memberType.GetGenericTypeDefinition();
+                    if (genericTypeDef == typeof(IDictionary<,>) || genericTypeDef == typeof(Dictionary<,>))
+                        continue;
+                }                
+
                 if (LogicBuilder.Expressions.Utils.TypeExtensions.IsList(memberType)
                     && LogicBuilder.Expressions.Utils.TypeExtensions.IsLiteralType
                         (

--- a/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
+++ b/AutoMapper.AspNetCore.OData.EFCore/LinqExtensions.cs
@@ -398,7 +398,7 @@ namespace AutoMapper.AspNet.OData
             (
                 expression.Type.IsIQueryable() ? typeof(Queryable) : typeof(Enumerable),
                 "Skip",
-                new[] { expression.GetUnderlyingElementType() },
+                new[] { LogicBuilder.Expressions.Utils.TypeExtensions.GetUnderlyingElementType(expression) },
                 expression,
                 Expression.Constant(skip.Value)
             );
@@ -412,7 +412,7 @@ namespace AutoMapper.AspNet.OData
             (
                 expression.Type.IsIQueryable() ? typeof(Queryable) : typeof(Enumerable),
                 "Take",
-                new[] { expression.GetUnderlyingElementType() },
+                new[] { LogicBuilder.Expressions.Utils.TypeExtensions.GetUnderlyingElementType(expression) },
                 expression,
                 Expression.Constant(top.Value)
             );
@@ -433,7 +433,7 @@ namespace AutoMapper.AspNet.OData
 
         public static Expression GetOrderByCountCall(this Expression expression, CountNode countNode, string methodName, ODataQueryContext context, string selectorParameterName = "a")
         {
-            Type sourceType = expression.GetUnderlyingElementType();
+            Type sourceType = LogicBuilder.Expressions.Utils.TypeExtensions.GetUnderlyingElementType(expression);
             ParameterExpression param = Expression.Parameter(sourceType, selectorParameterName);
 
             Expression countSelector;
@@ -441,7 +441,7 @@ namespace AutoMapper.AspNet.OData
             if (countNode.FilterClause is not null)
             {
                 string memberFullName = countNode.GetPropertyPath();
-                Type filterType = sourceType.GetMemberInfoFromFullName(memberFullName).GetMemberType().GetUnderlyingElementType();
+                Type filterType = LogicBuilder.Expressions.Utils.TypeExtensions.GetUnderlyingElementType(sourceType.GetMemberInfoFromFullName(memberFullName).GetMemberType());
                 LambdaExpression filterExpression = countNode.FilterClause.GetFilterExpression(filterType, context);
                 countSelector = param.MakeSelector(memberFullName).GetCountCall(filterExpression);
             }
@@ -465,7 +465,7 @@ namespace AutoMapper.AspNet.OData
 
         public static Expression GetOrderByCall(this Expression expression, string memberFullName, string methodName, string selectorParameterName = "a")
         {
-            Type sourceType = expression.GetUnderlyingElementType();
+            Type sourceType = LogicBuilder.Expressions.Utils.TypeExtensions.GetUnderlyingElementType(expression);
             MemberInfo memberInfo = sourceType.GetMemberInfoFromFullName(memberFullName);
             return Expression.Call
             (

--- a/AutoMapper.OData.EFCore.Tests/AirVinylData/AirVinylDatabaseInitializer.cs
+++ b/AutoMapper.OData.EFCore.Tests/AirVinylData/AirVinylDatabaseInitializer.cs
@@ -302,9 +302,15 @@ namespace AutoMapper.OData.EFCore.Tests.AirVinylData
 
             context.DynamicVinylRecordProperties.Add(new DynamicProperty()
             {
-                VinylRecordId = vinylRecords.First(r => r.Title == "Nevermind").VinylRecordId,//1,
+                VinylRecordId = vinylRecords.First(r => r.Title == "Nevermind").VinylRecordId,//1
                 Key = "Publisher",
                 Value = "Geffen"
+            });
+            context.DynamicVinylRecordProperties.Add(new DynamicProperty()
+            {
+                VinylRecordId = vinylRecords.First(r => r.Title == "Nevermind").VinylRecordId,//1
+                Key = "SomeData",
+                Value = new { TestProp = "value" }
             });
             context.SaveChanges();
 

--- a/AutoMapper.OData.EFCore.Tests/AirVinylModel/VinylLinkModel.cs
+++ b/AutoMapper.OData.EFCore.Tests/AirVinylModel/VinylLinkModel.cs
@@ -1,0 +1,7 @@
+﻿namespace AutoMapper.OData.EFCore.Tests.AirVinylModel
+{
+    public class VinylLinkModel
+    {
+        public string Href { get; set; }
+    }
+}

--- a/AutoMapper.OData.EFCore.Tests/AirVinylModel/VinylRecordModel.cs
+++ b/AutoMapper.OData.EFCore.Tests/AirVinylModel/VinylRecordModel.cs
@@ -33,5 +33,22 @@ namespace AutoMapper.OData.EFCore.Tests.AirVinylModel
             = new List<DynamicPropertyModel>();
 
         public IDictionary<string, object> Properties { get; set; }
+
+        private Dictionary<string, VinylLinkModel> _links;
+        public IDictionary<string, VinylLinkModel> Links { 
+            get 
+            {
+                if (_links is null)
+                {
+                    _links = new Dictionary<string, VinylLinkModel>()
+                    {
+                        { "buyingLink", new VinylLinkModel { Href = $"http://test/buy/{VinylRecordId}" } },
+                        { "reviewLink", new VinylLinkModel { Href = $"http://test/review/{VinylRecordId}" } }
+                    };
+                }
+
+                return _links;
+            } 
+        }            
     }
 }

--- a/AutoMapper.OData.EFCore.Tests/ExpansionTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/ExpansionTests.cs
@@ -43,6 +43,26 @@ namespace AutoMapper.OData.EFCore.Tests
         }
 
         [Fact]
+        public async Task GetVinylRecordsExpandsComplexTypesByDefault()
+        {
+            string query = "/vinylrecordmodel";
+            Test(await GetAsync<VinylRecordModel, VinylRecord>(query));
+
+            void Test(ICollection<VinylRecordModel> collection)
+            {
+                Assert.True(collection.Count > 0);
+
+                //Navigation properties
+                Assert.True(collection.All(vinyl => vinyl.Person is null));
+                Assert.True(collection.All(vinyl => vinyl.PressingDetail is null));
+                
+                //Complex types
+                Assert.Contains(collection, vinyl => vinyl.Properties.Count != 0);
+                Assert.Contains(collection, vinyl => vinyl.DynamicVinylRecordProperties.Count != 0);
+            }
+        }
+
+        [Fact]
         public async Task GetRecordStoresExpandsComplexTypesByDefault()
         {
             string query = "/recordstoremodel";

--- a/AutoMapper.OData.EFCore.Tests/ExpansionTests.cs
+++ b/AutoMapper.OData.EFCore.Tests/ExpansionTests.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper.AspNet.OData;
 using AutoMapper.OData.EFCore.Tests.AirVinylData;
 using AutoMapper.OData.EFCore.Tests.AirVinylModel;
+using LogicBuilder.Expressions.Utils;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.OData;
 using Microsoft.AspNetCore.OData.Query;
@@ -58,7 +59,9 @@ namespace AutoMapper.OData.EFCore.Tests
                 
                 //Complex types
                 Assert.Contains(collection, vinyl => vinyl.Properties.Count != 0);
+                Assert.Contains(collection, vinyl => vinyl.Properties.Any(p => !p.Value.GetType().IsLiteralType()));
                 Assert.Contains(collection, vinyl => vinyl.DynamicVinylRecordProperties.Count != 0);
+                Assert.Contains(collection, vinyl => vinyl.Links.Count != 0);
             }
         }
 

--- a/AutoMapper.OData.EFCore.Tests/Mappings/AirVinylMappings.cs
+++ b/AutoMapper.OData.EFCore.Tests/Mappings/AirVinylMappings.cs
@@ -30,6 +30,7 @@ namespace AutoMapper.OData.EFCore.Tests.Mappings
             CreateMap<SpecializedRecordStore, SpecializedRecordStoreModel>()
                 .ForAllMembers(o => o.ExplicitExpansion());
             CreateMap<VinylRecord, VinylRecordModel>()
+                .ForMember(dest => dest.Links, o => o.Ignore())
                 .ForAllMembers(o => o.ExplicitExpansion());
         }
     }


### PR DESCRIPTION
Hi @BlaiseD,
 
Related to #239.

I think I added what was missing to support default expansion of dictionaries.

I was wondering if I would need to do do some code to select child properties of the dictionary values when TValue is an object with properties. i.e. `Dictionary<string, MyObj> and MyObj is a complex type.